### PR TITLE
Fix ElevatedButton constructor in network diagram tab

### DIFF
--- a/nw_checker/lib/main.dart
+++ b/nw_checker/lib/main.dart
@@ -65,7 +65,7 @@ class HomePage extends StatelessWidget {
               ),
             ),
             Center(
-              child: ElevatedButton
+              child: ElevatedButton(
                 onPressed: () {
                   ScaffoldMessenger.of(context).showSnackBar(
                     const SnackBar(


### PR DESCRIPTION
## Summary
- fix missing constructor parentheses for network diagram tab button

## Testing
- `flutter test` *(fails: Expected exactly one matching candidate, found 0 with text "動的スキャンを実行しました")*

------
https://chatgpt.com/codex/tasks/task_e_6891c49998a4832394df3dc95a8844c8