### PR TITLE
Implement nmap-based port scanning and add mocked tests

### DIFF
--- a/src/discover_hosts.py
+++ b/src/discover_hosts.py
@@ -8,4 +8,5 @@ def discover_hosts(subnet: str):
     Returns:
         list of IP addresses or host details.
     """
-    pass
+    # TODO: Implement real host discovery.
+    return []

--- a/src/port_scan.py
+++ b/src/port_scan.py
@@ -2,10 +2,27 @@
 Port scanning utilities.
 """
 
+import nmap
+
+
 def scan_ports(target_ip: str):
-    """
-    Scan open ports on the target IP.
+    """Scan open ports on the target IP.
+
+    Args:
+        target_ip: IP address to scan.
+
     Returns:
-        list of open ports.
+        list of open ports as integers.
     """
-    pass
+    scanner = nmap.PortScanner()
+    # `-p-` instructs nmap to scan all ports
+    scan_data = scanner.scan(target_ip, arguments="-p-")
+
+    open_ports = []
+    host_info = scan_data.get("scan", {}).get(target_ip, {})
+    for proto, ports in host_info.items():
+        for port, info in ports.items():
+            if info.get("state") == "open":
+                open_ports.append(port)
+
+    return open_ports

--- a/tests/test_port_scan.py
+++ b/tests/test_port_scan.py
@@ -1,6 +1,25 @@
+import nmap
 import pytest
 from src.port_scan import scan_ports
 
-def test_scan_ports_runs():
+def test_scan_ports_returns_only_open_ports(monkeypatch):
+    fake_result = {
+        "scan": {
+            "127.0.0.1": {
+                "tcp": {
+                    22: {"state": "open"},
+                    80: {"state": "closed"},
+                    443: {"state": "open"},
+                }
+            }
+        }
+    }
+
+    class FakeScanner:
+        def scan(self, target_ip, arguments=""):
+            return fake_result
+
+    monkeypatch.setattr(nmap, "PortScanner", lambda: FakeScanner())
+
     result = scan_ports("127.0.0.1")
-    assert isinstance(result, list)
+    assert result == [22, 443]


### PR DESCRIPTION
## Summary
- Implement `scan_ports` using `nmap.PortScanner` and return only open ports
- Add mocked unit test for `scan_ports`
- Provide placeholder return for `discover_hosts`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891f2d44c208323b54509e76215947d