### PR TITLE
Add test for scan error handling

### DIFF
--- a/tests/test_port_scan.py
+++ b/tests/test_port_scan.py
@@ -23,3 +23,14 @@ def test_scan_ports_returns_only_open_ports(monkeypatch):
 
     result = scan_ports("127.0.0.1")
     assert result == [22, 443]
+
+
+def test_scan_ports_handles_scan_errors(monkeypatch):
+    class ErrorScanner:
+        def scan(self, target_ip, arguments=""):
+            raise nmap.PortScannerError("scan failed")
+
+    monkeypatch.setattr(nmap, "PortScanner", lambda: ErrorScanner())
+
+    with pytest.raises(nmap.PortScannerError):
+        scan_ports("127.0.0.1")


### PR DESCRIPTION
## Summary
- add test ensuring `scan_ports` propagates nmap errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891f9e5092c832387aa58adc5c83cca