### PR TITLE
Add test for handling closed ports in scan_ports

### DIFF
--- a/tests/test_port_scan.py
+++ b/tests/test_port_scan.py
@@ -23,3 +23,25 @@ def test_scan_ports_returns_only_open_ports(monkeypatch):
 
     result = scan_ports("127.0.0.1")
     assert result == [22, 443]
+
+
+def test_scan_ports_all_closed_ports(monkeypatch):
+    fake_result = {
+        "scan": {
+            "127.0.0.1": {
+                "tcp": {
+                    22: {"state": "closed"},
+                    80: {"state": "closed"},
+                }
+            }
+        }
+    }
+
+    class FakeScanner:
+        def scan(self, target_ip, arguments=""):
+            return fake_result
+
+    monkeypatch.setattr(nmap, "PortScanner", lambda: FakeScanner())
+
+    result = scan_ports("127.0.0.1")
+    assert result == []


### PR DESCRIPTION
## Summary
- add unit test verifying scan_ports returns empty list when all ports closed

## Testing
- `pytest`
- `bash flutter_env.sh` *(fails: `flutter: command not found`)*
- `apt-get install -y flutter` *(fails: `Unable to locate package flutter`)*

------
https://chatgpt.com/codex/tasks/task_e_6891f9dd0e408323bd5e49acd26edf61