### PR TITLE
feat: show test output in monospace view

### DIFF
--- a/nw_checker/lib/main.dart
+++ b/nw_checker/lib/main.dart
@@ -20,7 +20,33 @@ class MyApp extends StatelessWidget {
 }
 
 class HomePage extends StatelessWidget {
-  const HomePage({super.key});
+  const HomePage({super.key, this.testOutput = _dummyTestOutput});
+
+  /// 表示する診断結果（後でPython側から差し替え予定）
+  final String testOutput;
+
+  /// 仮の診断結果（ダミーデータ）
+  static const String _dummyTestOutput = '''
+[SCAN] TCP 3389 OPEN :: HIGH RISK (RDP) [WARN]
+[SCAN] TCP 445 OPEN :: HIGH RISK (SMB) [WARN]
+[SCAN] TCP 21 OPEN :: FTP (ANON) [WARN]
+[SCAN] TCP 80 OPEN :: HTTP/1.1
+NOTE: Multiple external ports detected.
+
+[BANNER] 192.168.1.10:445 OS: WinServer2012R2 (EOL)
+[BANNER] 192.168.1.15:80 SVC: Apache/2.2.15 (VULNERABLE)
+
+[SMB] RESPONDING
+[NETBIOS] RESPONDING
+[UPNP] ENABLED
+[ARP] Multiple replies detected (protection: NONE)
+[DHCP] DUPLICATE (192.168.1.1 / 192.168.1.200)
+[DNS] External: 8.8.8.8 / 114.114.114.114
+[SSL] example.co.jp EXP: 12 days (AUTORENEW: DISABLED)
+RISK SCORE: 92/100
+STATUS: CRITICAL
+(output truncated)
+''';
 
   @override
   Widget build(BuildContext context) {
@@ -44,9 +70,7 @@ class HomePage extends StatelessWidget {
               child: ElevatedButton(
                 onPressed: () {
                   ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(
-                      content: Text('静的スキャンを実行しました'),
-                    ),
+                    const SnackBar(content: Text('静的スキャンを実行しました')),
                   );
                 },
                 child: const Text('静的スキャンを実行'),
@@ -56,9 +80,7 @@ class HomePage extends StatelessWidget {
               child: ElevatedButton(
                 onPressed: () {
                   ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(
-                      content: Text('動的スキャンを実行しました'),
-                    ),
+                    const SnackBar(content: Text('動的スキャンを実行しました')),
                   );
                 },
                 child: const Text('動的スキャンを実行'),
@@ -68,24 +90,27 @@ class HomePage extends StatelessWidget {
               child: ElevatedButton(
                 onPressed: () {
                   ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(
-                      content: Text('ネットワーク図を表示しました'),
-                    ),
+                    const SnackBar(content: Text('ネットワーク図を表示しました')),
                   );
                 },
                 child: const Text('ネットワーク図を表示'),
               ),
             ),
-            Center(
-              child: ElevatedButton(
-                onPressed: () {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(
-                      content: Text('テストを開始しました'),
+            Container(
+              color: Colors.white,
+              padding: const EdgeInsets.all(8.0),
+              child: Scrollbar(
+                thumbVisibility: true,
+                child: SingleChildScrollView(
+                  child: SelectableText(
+                    testOutput,
+                    style: const TextStyle(
+                      fontFamily: 'monospace',
+                      fontSize: 13,
+                      color: Colors.black,
                     ),
-                  );
-                },
-                child: const Text('テストを開始'),
+                  ),
+                ),
               ),
             ),
           ],

--- a/nw_checker/test/widget_test.dart
+++ b/nw_checker/test/widget_test.dart
@@ -4,8 +4,9 @@ import 'package:flutter/material.dart';
 import 'package:nw_checker/main.dart';
 
 void main() {
-  testWidgets('Tab bar contains four tabs with correct labels',
-      (WidgetTester tester) async {
+  testWidgets('Tab bar contains four tabs with correct labels', (
+    WidgetTester tester,
+  ) async {
     await tester.pumpWidget(const MyApp());
 
     expect(find.byType(Tab), findsNWidgets(4));
@@ -15,7 +16,7 @@ void main() {
     expect(find.text('テスト'), findsOneWidget);
   });
 
-  testWidgets('Each tab shows its button', (WidgetTester tester) async {
+  testWidgets('Each tab shows expected content', (WidgetTester tester) async {
     await tester.pumpWidget(const MyApp());
 
     // 静的スキャン tab is selected by default
@@ -31,36 +32,51 @@ void main() {
 
     await tester.tap(find.text('テスト'));
     await tester.pumpAndSettle();
-    expect(find.text('テストを開始'), findsOneWidget);
+    expect(find.byType(SelectableText), findsOneWidget);
+    expect(find.textContaining('[SCAN] TCP 3389 OPEN'), findsOneWidget);
   });
 
-  testWidgets('Pressing each button shows a SnackBar',
-      (WidgetTester tester) async {
+  testWidgets('Static button shows a SnackBar', (WidgetTester tester) async {
     await tester.pumpWidget(const MyApp());
 
     await tester.tap(find.text('静的スキャンを実行'));
     await tester.pump();
     expect(find.text('静的スキャンを実行しました'), findsOneWidget);
-    await tester.pump(const Duration(seconds: 4));
+  });
+
+  testWidgets('Dynamic button shows a SnackBar', (WidgetTester tester) async {
+    await tester.pumpWidget(const MyApp());
 
     await tester.tap(find.text('動的スキャン'));
     await tester.pumpAndSettle();
     await tester.tap(find.text('動的スキャンを実行'));
     await tester.pump();
     expect(find.text('動的スキャンを実行しました'), findsOneWidget);
-    await tester.pump(const Duration(seconds: 4));
+  });
+
+  testWidgets('Network button shows a SnackBar', (WidgetTester tester) async {
+    await tester.pumpWidget(const MyApp());
 
     await tester.tap(find.text('ネットワーク図'));
     await tester.pumpAndSettle();
     await tester.tap(find.text('ネットワーク図を表示'));
     await tester.pump();
     expect(find.text('ネットワーク図を表示しました'), findsOneWidget);
-    await tester.pump(const Duration(seconds: 4));
+  });
+
+  testWidgets('Test tab shows monospaced diagnostic text', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(const MyApp());
 
     await tester.tap(find.text('テスト'));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('テストを開始'));
-    await tester.pump();
-    expect(find.text('テストを開始しました'), findsOneWidget);
+
+    expect(find.byType(Scrollbar), findsOneWidget);
+    final selectable = tester.widget<SelectableText>(
+      find.byType(SelectableText),
+    );
+    expect(selectable.style?.fontFamily, 'monospace');
+    expect(selectable.data!.contains('RISK SCORE: 92/100'), isTrue);
   });
 }


### PR DESCRIPTION
## Summary
- display dummy network diagnostic result text in the Test tab with monospace font and scrollable white background
- add widget tests covering new Test tab behavior and restore SnackBar tests for all scan tabs

## Testing
- `pytest` (fails: AssertionError in tests/test_discover_hosts.py and tests/test_port_scan.py)
- `cd nw_checker && flutter test`


------
https://chatgpt.com/codex/tasks/task_e_6891f631cf04832388b6d49777ad7ede