### PR TITLE
Assign keys to tabs and buttons for widget tests

### DIFF
--- a/nw_checker/lib/main.dart
+++ b/nw_checker/lib/main.dart
@@ -31,61 +31,69 @@ class HomePage extends StatelessWidget {
           title: const Text('Network Checker'),
           bottom: const TabBar(
             tabs: [
-              Tab(text: '静的スキャン'),
-              Tab(text: '動的スキャン'),
-              Tab(text: 'ネットワーク図'),
-              Tab(text: 'テスト'),
+              Tab(key: Key('tab-static'), text: '静的スキャン'),
+              Tab(key: Key('tab-dynamic'), text: '動的スキャン'),
+              Tab(key: Key('tab-network'), text: 'ネットワーク図'),
+              Tab(key: Key('tab-test'), text: 'テスト'),
             ],
           ),
         ),
         body: TabBarView(
           children: [
             Center(
-              child: ElevatedButton(
-                onPressed: () {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(
-                      content: Text('静的スキャンを実行しました'),
+              child: Builder(
+                builder:
+                    (context) => ElevatedButton(
+                      key: const Key('btn-static'),
+                      onPressed: () {
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          const SnackBar(content: Text('静的スキャンを実行しました')),
+                        );
+                      },
+                      child: const Text('静的スキャンを実行'),
                     ),
-                  );
-                },
-                child: const Text('静的スキャンを実行'),
               ),
             ),
             Center(
-              child: ElevatedButton(
-                onPressed: () {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(
-                      content: Text('動的スキャンを実行しました'),
+              child: Builder(
+                builder:
+                    (context) => ElevatedButton(
+                      key: const Key('btn-dynamic'),
+                      onPressed: () {
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          const SnackBar(content: Text('動的スキャンを実行しました')),
+                        );
+                      },
+                      child: const Text('動的スキャンを実行'),
                     ),
-                  );
-                },
-                child: const Text('動的スキャンを実行'),
               ),
             ),
             Center(
-              child: ElevatedButton(
-                onPressed: () {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(
-                      content: Text('ネットワーク図を表示しました'),
+              child: Builder(
+                builder:
+                    (context) => ElevatedButton(
+                      key: const Key('btn-network'),
+                      onPressed: () {
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          const SnackBar(content: Text('ネットワーク図を表示しました')),
+                        );
+                      },
+                      child: const Text('ネットワーク図を表示'),
                     ),
-                  );
-                },
-                child: const Text('ネットワーク図を表示'),
               ),
             ),
             Center(
-              child: ElevatedButton(
-                onPressed: () {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(
-                      content: Text('テストを開始しました'),
+              child: Builder(
+                builder:
+                    (context) => ElevatedButton(
+                      key: const Key('btn-test'),
+                      onPressed: () {
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          const SnackBar(content: Text('テストを開始しました')),
+                        );
+                      },
+                      child: const Text('テストを開始'),
                     ),
-                  );
-                },
-                child: const Text('テストを開始'),
               ),
             ),
           ],

--- a/nw_checker/test/widget_test.dart
+++ b/nw_checker/test/widget_test.dart
@@ -4,62 +4,81 @@ import 'package:flutter/material.dart';
 import 'package:nw_checker/main.dart';
 
 void main() {
-  testWidgets('Tab bar contains four tabs with correct labels',
-      (WidgetTester tester) async {
+  testWidgets('Tab bar contains four tabs with correct labels', (
+    WidgetTester tester,
+  ) async {
     await tester.pumpWidget(const MyApp());
 
     expect(find.byType(Tab), findsNWidgets(4));
-    expect(find.text('静的スキャン'), findsOneWidget);
-    expect(find.text('動的スキャン'), findsOneWidget);
-    expect(find.text('ネットワーク図'), findsOneWidget);
-    expect(find.text('テスト'), findsOneWidget);
+    expect(find.byKey(const Key('tab-static')), findsOneWidget);
+    expect(
+      tester.widget<Tab>(find.byKey(const Key('tab-static'))).text,
+      '静的スキャン',
+    );
+    expect(find.byKey(const Key('tab-dynamic')), findsOneWidget);
+    expect(
+      tester.widget<Tab>(find.byKey(const Key('tab-dynamic'))).text,
+      '動的スキャン',
+    );
+    expect(find.byKey(const Key('tab-network')), findsOneWidget);
+    expect(
+      tester.widget<Tab>(find.byKey(const Key('tab-network'))).text,
+      'ネットワーク図',
+    );
+    expect(find.byKey(const Key('tab-test')), findsOneWidget);
+    expect(tester.widget<Tab>(find.byKey(const Key('tab-test'))).text, 'テスト');
   });
 
   testWidgets('Each tab shows its button', (WidgetTester tester) async {
     await tester.pumpWidget(const MyApp());
 
     // 静的スキャン tab is selected by default
-    expect(find.text('静的スキャンを実行'), findsOneWidget);
+    expect(find.byKey(const Key('btn-static')), findsOneWidget);
 
-    await tester.tap(find.text('動的スキャン'));
+    await tester.tap(find.byKey(const Key('tab-dynamic')));
     await tester.pumpAndSettle();
-    expect(find.text('動的スキャンを実行'), findsOneWidget);
+    expect(find.byKey(const Key('btn-dynamic')), findsOneWidget);
 
-    await tester.tap(find.text('ネットワーク図'));
+    await tester.tap(find.byKey(const Key('tab-network')));
     await tester.pumpAndSettle();
-    expect(find.text('ネットワーク図を表示'), findsOneWidget);
+    expect(find.byKey(const Key('btn-network')), findsOneWidget);
 
-    await tester.tap(find.text('テスト'));
+    await tester.tap(find.byKey(const Key('tab-test')));
     await tester.pumpAndSettle();
-    expect(find.text('テストを開始'), findsOneWidget);
+    expect(find.byKey(const Key('btn-test')), findsOneWidget);
   });
 
-  testWidgets('Pressing each button shows a SnackBar',
-      (WidgetTester tester) async {
+  testWidgets('Pressing each button shows a SnackBar', (
+    WidgetTester tester,
+  ) async {
     await tester.pumpWidget(const MyApp());
+    final scaffold = tester.element(find.byType(Scaffold));
 
-    await tester.tap(find.text('静的スキャンを実行'));
+    await tester.tap(find.byKey(const Key('btn-static')));
     await tester.pump();
     expect(find.text('静的スキャンを実行しました'), findsOneWidget);
-    await tester.pump(const Duration(seconds: 4));
+    ScaffoldMessenger.of(scaffold).clearSnackBars();
+    await tester.pump();
 
-    await tester.tap(find.text('動的スキャン'));
+    await tester.tap(find.byKey(const Key('tab-dynamic')));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('動的スキャンを実行'));
+    await tester.tap(find.byKey(const Key('btn-dynamic')));
     await tester.pump();
     expect(find.text('動的スキャンを実行しました'), findsOneWidget);
-    await tester.pump(const Duration(seconds: 4));
+    ScaffoldMessenger.of(scaffold).clearSnackBars();
+    await tester.pump();
 
-    await tester.tap(find.text('ネットワーク図'));
+    await tester.tap(find.byKey(const Key('tab-network')));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('ネットワーク図を表示'));
+    await tester.tap(find.byKey(const Key('btn-network')));
     await tester.pump();
     expect(find.text('ネットワーク図を表示しました'), findsOneWidget);
-    await tester.pump(const Duration(seconds: 4));
+    ScaffoldMessenger.of(scaffold).clearSnackBars();
+    await tester.pump();
 
-    await tester.tap(find.text('テスト'));
+    await tester.tap(find.byKey(const Key('tab-test')));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('テストを開始'));
+    await tester.tap(find.byKey(const Key('btn-test')));
     await tester.pump();
     expect(find.text('テストを開始しました'), findsOneWidget);
   });


### PR DESCRIPTION
## Summary
- give each tab and action button a unique `Key` and wrap buttons in `Builder` for proper context
- update widget tests to use `find.byKey` and ensure snack bars are cleared between checks

## Testing
- `pytest`
- `cd nw_checker && /root/flutter/bin/flutter test test/widget_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_6891ff4e2c7c8323b4013059e71afb6c