### PR TITLE
feat: add keys for tabs and buttons

### DIFF
--- a/nw_checker/lib/main.dart
+++ b/nw_checker/lib/main.dart
@@ -57,10 +57,10 @@ STATUS: CRITICAL
           title: const Text('Network Checker'),
           bottom: const TabBar(
             tabs: [
-              Tab(text: '静的スキャン'),
-              Tab(text: '動的スキャン'),
-              Tab(text: 'ネットワーク図'),
-              Tab(text: 'テスト'),
+              Tab(key: Key('staticTab'), text: '静的スキャン'),
+              Tab(key: Key('dynamicTab'), text: '動的スキャン'),
+              Tab(key: Key('networkTab'), text: 'ネットワーク図'),
+              Tab(key: Key('testTab'), text: 'テスト'),
             ],
           ),
         ),
@@ -68,6 +68,7 @@ STATUS: CRITICAL
           children: [
             Center(
               child: ElevatedButton(
+                key: const Key('staticButton'),
                 onPressed: () {
                   ScaffoldMessenger.of(context).showSnackBar(
                     const SnackBar(content: Text('静的スキャンを実行しました')),
@@ -78,6 +79,7 @@ STATUS: CRITICAL
             ),
             Center(
               child: ElevatedButton(
+                key: const Key('dynamicButton'),
                 onPressed: () {
                   ScaffoldMessenger.of(context).showSnackBar(
                     const SnackBar(content: Text('動的スキャンを実行しました')),
@@ -88,6 +90,7 @@ STATUS: CRITICAL
             ),
             Center(
               child: ElevatedButton(
+                key: const Key('networkButton'),
                 onPressed: () {
                   ScaffoldMessenger.of(context).showSnackBar(
                     const SnackBar(content: Text('ネットワーク図を表示しました')),

--- a/nw_checker/test/widget_test.dart
+++ b/nw_checker/test/widget_test.dart
@@ -10,36 +10,46 @@ void main() {
     await tester.pumpWidget(const MyApp());
 
     expect(find.byType(Tab), findsNWidgets(4));
-    expect(find.text('静的スキャン'), findsOneWidget);
-    expect(find.text('動的スキャン'), findsOneWidget);
-    expect(find.text('ネットワーク図'), findsOneWidget);
-    expect(find.text('テスト'), findsOneWidget);
+    expect(find.byKey(const Key('staticTab')), findsOneWidget);
+    expect(tester.widget<Tab>(find.byKey(const Key('staticTab'))).text,
+        '静的スキャン');
+    expect(find.byKey(const Key('dynamicTab')), findsOneWidget);
+    expect(tester.widget<Tab>(find.byKey(const Key('dynamicTab'))).text,
+        '動的スキャン');
+    expect(find.byKey(const Key('networkTab')), findsOneWidget);
+    expect(tester.widget<Tab>(find.byKey(const Key('networkTab'))).text,
+        'ネットワーク図');
+    expect(find.byKey(const Key('testTab')), findsOneWidget);
+    expect(
+        tester.widget<Tab>(find.byKey(const Key('testTab'))).text, 'テスト');
   });
 
   testWidgets('Each tab shows expected content', (WidgetTester tester) async {
     await tester.pumpWidget(const MyApp());
 
     // 静的スキャン tab is selected by default
-    expect(find.text('静的スキャンを実行'), findsOneWidget);
+    expect(find.byKey(const Key('staticButton')), findsOneWidget);
 
-    await tester.tap(find.text('動的スキャン'));
+    await tester.tap(find.byKey(const Key('dynamicTab')));
     await tester.pumpAndSettle();
-    expect(find.text('動的スキャンを実行'), findsOneWidget);
+    expect(find.byKey(const Key('dynamicButton')), findsOneWidget);
 
-    await tester.tap(find.text('ネットワーク図'));
+    await tester.tap(find.byKey(const Key('networkTab')));
     await tester.pumpAndSettle();
-    expect(find.text('ネットワーク図を表示'), findsOneWidget);
+    expect(find.byKey(const Key('networkButton')), findsOneWidget);
 
-    await tester.tap(find.text('テスト'));
+    await tester.tap(find.byKey(const Key('testTab')));
     await tester.pumpAndSettle();
     expect(find.byType(SelectableText), findsOneWidget);
-    expect(find.textContaining('[SCAN] TCP 3389 OPEN'), findsOneWidget);
+    final selectable =
+        tester.widget<SelectableText>(find.byType(SelectableText));
+    expect(selectable.data!.contains('[SCAN] TCP 3389 OPEN'), isTrue);
   });
 
   testWidgets('Static button shows a SnackBar', (WidgetTester tester) async {
     await tester.pumpWidget(const MyApp());
 
-    await tester.tap(find.text('静的スキャンを実行'));
+    await tester.tap(find.byKey(const Key('staticButton')));
     await tester.pump();
     expect(find.text('静的スキャンを実行しました'), findsOneWidget);
   });
@@ -47,9 +57,9 @@ void main() {
   testWidgets('Dynamic button shows a SnackBar', (WidgetTester tester) async {
     await tester.pumpWidget(const MyApp());
 
-    await tester.tap(find.text('動的スキャン'));
+    await tester.tap(find.byKey(const Key('dynamicTab')));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('動的スキャンを実行'));
+    await tester.tap(find.byKey(const Key('dynamicButton')));
     await tester.pump();
     expect(find.text('動的スキャンを実行しました'), findsOneWidget);
   });
@@ -57,9 +67,9 @@ void main() {
   testWidgets('Network button shows a SnackBar', (WidgetTester tester) async {
     await tester.pumpWidget(const MyApp());
 
-    await tester.tap(find.text('ネットワーク図'));
+    await tester.tap(find.byKey(const Key('networkTab')));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('ネットワーク図を表示'));
+    await tester.tap(find.byKey(const Key('networkButton')));
     await tester.pump();
     expect(find.text('ネットワーク図を表示しました'), findsOneWidget);
   });
@@ -69,7 +79,7 @@ void main() {
   ) async {
     await tester.pumpWidget(const MyApp());
 
-    await tester.tap(find.text('テスト'));
+    await tester.tap(find.byKey(const Key('testTab')));
     await tester.pumpAndSettle();
 
     expect(find.byType(Scrollbar), findsOneWidget);


### PR DESCRIPTION
## Summary
- assign unique `Key` values to each tab and action button
- migrate widget tests to `find.byKey` selectors

## Testing
- `pytest`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_689203c31a0883238c5ad6f01591b0c5