### PR TITLE
refine test report ui

### DIFF
--- a/nw_checker/test/widget_test.dart
+++ b/nw_checker/test/widget_test.dart
@@ -105,13 +105,14 @@ void main() {
     );
     expect(selectable.style?.fontFamily, 'Courier New');
     final text = selectable.textSpan!.toPlainText();
-    expect(text.contains('RISK SCORE: 92/100'), isTrue);
+    expect(text.contains('RISK SCORE: 97/100'), isTrue);
 
     bool hasWarnSpan = false;
     (selectable.textSpan as TextSpan).visitChildren((span) {
       if (span is TextSpan &&
           span.text == '[WARN]' &&
-          span.style?.color == const Color(0xFFCC0000)) {
+          span.style?.color == const Color(0xFFB71C1C) &&
+          span.style?.backgroundColor == const Color(0xFFFFEBEE)) {
         hasWarnSpan = true;
         return false;
       }
@@ -128,7 +129,7 @@ void main() {
           .first,
     );
     final BoxDecoration deco = container.decoration as BoxDecoration;
-    expect(deco.color, const Color(0xFFFAFAFA));
-    expect((deco.border as Border).top.color, const Color(0xFF999999));
+    expect(deco.color, Colors.white);
+    expect(deco.boxShadow?.isNotEmpty ?? false, isTrue);
   });
 }


### PR DESCRIPTION
## Summary
- restyle test tab report with darker background, fixed-width white output and bold monospaced text
- highlight warnings and status with new color scheme and label styles
- update widget tests for revised report layout and content

## Testing
- `bash setup.sh` *(fails: KeyboardInterrupt during venv creation)*
- `bash flutter_env.sh` *(fails: command not found: flutter)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'nmap')*
- `cd nw_checker && flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68920f86e6488323abcb0291db58dba5