### PR TITLE
Refactor HomePage tabs to use explicit TabController

### DIFF
--- a/nw_checker/lib/main.dart
+++ b/nw_checker/lib/main.dart
@@ -50,9 +50,16 @@ class HomePage extends StatefulWidget {
   State<HomePage> createState() => _HomePageState();
 }
 
-class _HomePageState extends State<HomePage> {
+class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
   bool _showTestOutput = false;
   bool _isLoading = false;
+  late TabController _tabController;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 4, vsync: this);
+  }
 
   List<InlineSpan> _buildOutputSpans(Iterable<String> lines) {
     const warnStyle = TextStyle(
@@ -146,112 +153,117 @@ class _HomePageState extends State<HomePage> {
   }
 
   @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return DefaultTabController(
-      length: 4,
-      child: Scaffold(
-        appBar: AppBar(
-          title: const Text('Network Checker'),
-          bottom: const TabBar(
-            tabs: [
-              Tab(key: Key('staticTab'), text: '静的スキャン'),
-              Tab(key: Key('dynamicTab'), text: '動的スキャン'),
-              Tab(key: Key('networkTab'), text: 'ネットワーク図'),
-              Tab(key: Key('testTab'), text: 'テスト'),
-            ],
-          ),
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Network Checker'),
+        bottom: TabBar(
+          controller: _tabController,
+          tabs: const [
+            Tab(key: Key('staticTab'), text: '静的スキャン'),
+            Tab(key: Key('dynamicTab'), text: '動的スキャン'),
+            Tab(key: Key('networkTab'), text: 'ネットワーク図'),
+            Tab(key: Key('testTab'), text: 'テスト'),
+          ],
         ),
-        body: TabBarView(
-          children: [
-            Center(
-              child: ElevatedButton(
-                key: const Key('staticButton'),
-                onPressed: () {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(content: Text('テストを実行しました')),
-                  );
-                },
-                child: const Text('テスト'),
-              ),
+      ),
+      body: TabBarView(
+        controller: _tabController,
+        children: [
+          Center(
+            child: ElevatedButton(
+              key: const Key('staticButton'),
+              onPressed: () {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(content: Text('テストを実行しました')),
+                );
+              },
+              child: const Text('テスト'),
             ),
-            Center(
-              child: ElevatedButton(
-                key: const Key('dynamicButton'),
-                onPressed: () {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(content: Text('動的スキャンを実行しました')),
-                  );
-                },
-                child: const Text('動的スキャンを実行'),
-              ),
+          ),
+          Center(
+            child: ElevatedButton(
+              key: const Key('dynamicButton'),
+              onPressed: () {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(content: Text('動的スキャンを実行しました')),
+                );
+              },
+              child: const Text('動的スキャンを実行'),
             ),
-            Center(
-              child: ElevatedButton(
-                key: const Key('networkButton'),
-                onPressed: () {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(content: Text('ネットワーク図を表示しました')),
-                  );
-                },
-                child: const Text('ネットワーク図を表示'),
-              ),
+          ),
+          Center(
+            child: ElevatedButton(
+              key: const Key('networkButton'),
+              onPressed: () {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(content: Text('ネットワーク図を表示しました')),
+                );
+              },
+              child: const Text('ネットワーク図を表示'),
             ),
-            Padding(
-              padding: const EdgeInsets.all(8.0),
-              child: Column(
-                children: [
-                  ElevatedButton(
-                    onPressed: () {
+          ),
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Column(
+              children: [
+                ElevatedButton(
+                  onPressed: () {
+                    setState(() {
+                      _isLoading = true;
+                      _showTestOutput = false;
+                    });
+                    Future.delayed(const Duration(seconds: 90), () {
+                      if (!mounted) return;
                       setState(() {
-                        _isLoading = true;
-                        _showTestOutput = false;
+                        _isLoading = false;
+                        _showTestOutput = true;
                       });
-                      Future.delayed(const Duration(seconds: 90), () {
-                        if (!mounted) return;
-                        setState(() {
-                          _isLoading = false;
-                          _showTestOutput = true;
-                        });
-                      });
-                    },
-                    child: const Text('テストを実行'),
-                  ),
-                  if (_isLoading)
-                    const Expanded(
-                      child: Center(child: CircularProgressIndicator()),
-                    )
-                  else if (_showTestOutput)
-                    Expanded(
-                      child: Container(
-                        color: const Color(0xFFF4F4F4),
-                        alignment: Alignment.topCenter,
-                        child: Scrollbar(
-                          thumbVisibility: true,
-                          child: SingleChildScrollView(
-                            child: Container(
-                              width: 700,
-                              margin: const EdgeInsets.symmetric(vertical: 16),
-                              padding: const EdgeInsets.all(16),
-                              decoration: BoxDecoration(
-                                color: Colors.white,
-                                boxShadow: [
-                                  BoxShadow(
-                                    color: Colors.black.withOpacity(0.15),
-                                    blurRadius: 8,
-                                  ),
-                                ],
-                              ),
-                              child: _buildReportContent(),
+                    });
+                  },
+                  child: const Text('テストを実行'),
+                ),
+                if (_isLoading)
+                  const Expanded(
+                    child: Center(child: CircularProgressIndicator()),
+                  )
+                else if (_showTestOutput)
+                  Expanded(
+                    child: Container(
+                      color: const Color(0xFFF4F4F4),
+                      alignment: Alignment.topCenter,
+                      child: Scrollbar(
+                        thumbVisibility: true,
+                        child: SingleChildScrollView(
+                          child: Container(
+                            width: 700,
+                            margin: const EdgeInsets.symmetric(vertical: 16),
+                            padding: const EdgeInsets.all(16),
+                            decoration: BoxDecoration(
+                              color: Colors.white,
+                              boxShadow: [
+                                BoxShadow(
+                                  color: Colors.black.withOpacity(0.15),
+                                  blurRadius: 8,
+                                ),
+                              ],
                             ),
+                            child: _buildReportContent(),
                           ),
                         ),
                       ),
                     ),
-                ],
-              ),
+                  ),
+              ],
             ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }


### PR DESCRIPTION
## Summary
- manage tab state with TickerProviderStateMixin and TabController
- remove DefaultTabController wrapper and wire TabBar/TabBarView to controller
- dispose TabController to avoid reinitialization

## Testing
- `pytest` *(fails: assert [] == [22, 443]; Failed: DID NOT RAISE <class 'nmap.nmap.PortScannerError'>)*
- `cd nw_checker && flutter test`

------
https://chatgpt.com/codex/tasks/task_e_689296d82b788323a0ed4d9d1c656c7f