### PR TITLE
Add dynamic scan tab with API service

### DIFF
--- a/nw_checker/lib/dynamic_scan_tab.dart
+++ b/nw_checker/lib/dynamic_scan_tab.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+import 'services/dynamic_scan_api.dart';
+
+class DynamicScanTab extends StatefulWidget {
+  const DynamicScanTab({super.key});
+
+  @override
+  State<DynamicScanTab> createState() => _DynamicScanTabState();
+}
+
+class _DynamicScanTabState extends State<DynamicScanTab> {
+  Stream<List<String>>? _resultStream;
+  bool _isScanning = false;
+
+  Future<void> _start() async {
+    await startScan();
+    setState(() {
+      _isScanning = true;
+      _resultStream = fetchResults();
+    });
+  }
+
+  Future<void> _stop() async {
+    await stopScan();
+    setState(() {
+      _isScanning = false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            ElevatedButton(
+              key: const Key('startScanButton'),
+              onPressed: _isScanning ? null : _start,
+              child: const Text('スキャン開始'),
+            ),
+            const SizedBox(width: 8),
+            ElevatedButton(
+              key: const Key('stopScanButton'),
+              onPressed: _isScanning ? _stop : null,
+              child: const Text('スキャン停止'),
+            ),
+          ],
+        ),
+        const SizedBox(height: 16),
+        Expanded(
+          child: _resultStream == null
+              ? const Center(child: Text('スキャン結果はありません'))
+              : StreamBuilder<List<String>>(
+                  stream: _resultStream,
+                  builder: (context, snapshot) {
+                    if (snapshot.connectionState == ConnectionState.waiting ||
+                        (_isScanning && !snapshot.hasData)) {
+                      return const Center(child: CircularProgressIndicator());
+                    }
+                    final lines = snapshot.data ?? [];
+                    if (lines.isEmpty) {
+                      return const Center(child: Text('結果がありません'));
+                    }
+                    return ListView.builder(
+                      itemCount: lines.length,
+                      itemBuilder: (context, index) {
+                        return SelectableText(lines[index]);
+                      },
+                    );
+                  },
+                ),
+        ),
+      ],
+    );
+  }
+}
+

--- a/nw_checker/lib/main.dart
+++ b/nw_checker/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'dynamic_scan_tab.dart';
 
 void main() {
   runApp(const MyApp());
@@ -174,17 +175,7 @@ class _HomePageState extends State<HomePage> {
                 child: const Text('テスト'),
               ),
             ),
-            Center(
-              child: ElevatedButton(
-                key: const Key('dynamicButton'),
-                onPressed: () {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(content: Text('動的スキャンを実行しました')),
-                  );
-                },
-                child: const Text('動的スキャンを実行'),
-              ),
-            ),
+            const DynamicScanTab(),
             Center(
               child: ElevatedButton(
                 key: const Key('networkButton'),

--- a/nw_checker/lib/services/dynamic_scan_api.dart
+++ b/nw_checker/lib/services/dynamic_scan_api.dart
@@ -1,0 +1,45 @@
+import 'dart:async';
+
+// ダミーデータを提供する動的スキャンAPI
+final _dummyLines = <String>[
+  'Starting dynamic scan...',
+  'Scanning open ports...',
+  'Analyzing network traffic...',
+  'Scan complete.'
+];
+
+StreamController<List<String>>? _controller;
+Timer? _timer;
+
+/// スキャンを開始し、ダミー結果を順次ストリームへ流す
+Future<void> startScan() async {
+  await stopScan();
+  _controller = StreamController<List<String>>.broadcast();
+  final results = <String>[];
+  var index = 0;
+  _timer = Timer.periodic(const Duration(seconds: 1), (timer) {
+    if (index >= _dummyLines.length) {
+      timer.cancel();
+      _controller?.add(results);
+      _controller?.close();
+    } else {
+      results.add(_dummyLines[index]);
+      _controller?.add(List.from(results));
+      index++;
+    }
+  });
+}
+
+/// スキャンを停止する
+Future<void> stopScan() async {
+  _timer?.cancel();
+  _timer = null;
+  await _controller?.close();
+  _controller = null;
+}
+
+/// スキャン結果をストリームとして取得する
+Stream<List<String>> fetchResults() {
+  return _controller?.stream ?? const Stream<List<String>>.empty();
+}
+

--- a/nw_checker/test/dynamic_scan_tab_test.dart
+++ b/nw_checker/test/dynamic_scan_tab_test.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nw_checker/dynamic_scan_tab.dart';
+
+void main() {
+  testWidgets('DynamicScanTab has start and stop buttons', (tester) async {
+    await tester.pumpWidget(const MaterialApp(home: DynamicScanTab()));
+    expect(find.text('スキャン開始'), findsOneWidget);
+    expect(find.text('スキャン停止'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add dynamic scan API service with start/stop/fetch functions
- create DynamicScanTab widget with controls and result stream
- wire DynamicScanTab into main tab bar and add basic widget test

## Testing
- `dart format lib/dynamic_scan_tab.dart lib/services/dynamic_scan_api.dart lib/main.dart test/dynamic_scan_tab_test.dart` (fails: command not found)
- `flutter test` (fails: command not found)

------
https://chatgpt.com/codex/tasks/task_e_689297ba8f5c8323823cc082955a9d9f