### PR TITLE
Add placeholder network scan modules

### DIFF
--- a/src/port_scan.py
+++ b/src/port_scan.py
@@ -14,15 +14,15 @@ def scan_ports(target_ip: str):
     Returns:
         list of open ports as integers.
     """
-    # 現状は実スキャンを行わず空のリストを返す（後で実装予定）
-    return []
     scanner = nmap.PortScanner()
     # `-p-` instructs nmap to scan all ports
     scan_data = scanner.scan(target_ip, arguments="-p-")
 
-    open_ports = []
+    open_ports: list[int] = []
     host_info = scan_data.get("scan", {}).get(target_ip, {})
     for proto, ports in host_info.items():
+        if proto not in {"tcp", "udp"}:
+            continue
         for port, info in ports.items():
             if info.get("state") == "open":
                 open_ports.append(port)

--- a/src/scans/arp_spoof.py
+++ b/src/scans/arp_spoof.py
@@ -1,0 +1,13 @@
+"""Detect ARP spoofing attempts."""
+
+from scapy.all import sniff, ARP  # type: ignore
+
+
+def scan(interface: str | None = None) -> dict:
+    """Listen for suspicious ARP replies."""
+    try:
+        _ = (sniff, ARP)  # 実装は後日
+        details = {"alerts": []}
+        return {"category": "arp_spoof", "score": 0, "details": details}
+    except Exception as exc:
+        return {"category": "arp_spoof", "score": 0, "details": {"error": str(exc)}}

--- a/src/scans/dhcp.py
+++ b/src/scans/dhcp.py
@@ -1,0 +1,13 @@
+"""Detect rogue DHCP servers."""
+
+from scapy.all import DHCP, sniff  # type: ignore
+
+
+def scan(interface: str | None = None) -> dict:
+    """Look for multiple DHCP offers."""
+    try:
+        _ = (DHCP, sniff)  # Placeholder
+        details = {"servers": []}
+        return {"category": "dhcp", "score": 0, "details": details}
+    except Exception as exc:
+        return {"category": "dhcp", "score": 0, "details": {"error": str(exc)}}

--- a/src/scans/dns.py
+++ b/src/scans/dns.py
@@ -1,0 +1,13 @@
+"""DNS resolution checks."""
+
+from scapy.all import sr1, IP, UDP, DNS, DNSQR  # type: ignore
+
+
+def scan(name: str, server: str = "8.8.8.8") -> dict:
+    """Query DNS server for a record."""
+    try:
+        _ = (sr1, IP, UDP, DNS, DNSQR)  # Placeholder
+        details = {"query": name, "answers": []}
+        return {"category": "dns", "score": 0, "details": details}
+    except Exception as exc:
+        return {"category": "dns", "score": 0, "details": {"error": str(exc)}}

--- a/src/scans/os_banner.py
+++ b/src/scans/os_banner.py
@@ -1,0 +1,23 @@
+"""OS banner grabbing using nmap."""
+
+import nmap
+
+
+def scan(target: str) -> dict:
+    """Attempt to detect OS information for the target.
+
+    Args:
+        target: Host to fingerprint.
+
+    Returns:
+        dict: {"category": "os_banner", "score": int, "details": {"os": str}}
+    """
+    scanner = nmap.PortScanner()
+    try:
+        result = scanner.scan(target, arguments="-O")
+        os_matches = result.get("scan", {}).get(target, {}).get("osmatch", [])
+        os_name = os_matches[0]["name"] if os_matches else "unknown"
+        score = 0 if os_matches else -10
+        return {"category": "os_banner", "score": score, "details": {"os": os_name}}
+    except Exception as exc:
+        return {"category": "os_banner", "score": 0, "details": {"error": str(exc)}}

--- a/src/scans/ports.py
+++ b/src/scans/ports.py
@@ -1,0 +1,29 @@
+"""Port scan analysis returning unified result."""
+
+import nmap
+
+
+def scan(target: str) -> dict:
+    """Scan open ports on a target host.
+
+    Args:
+        target: IP or hostname to scan.
+
+    Returns:
+        dict: {"category": "ports", "score": int, "details": {"open_ports": list}}
+    """
+    scanner = nmap.PortScanner()
+    try:
+        scan_data = scanner.scan(target, arguments="-F")
+        open_ports: list[int] = []
+        host_info = scan_data.get("scan", {}).get(target, {})
+        for proto, ports in host_info.items():
+            if proto not in {"tcp", "udp"}:
+                continue
+            for port, info in ports.items():
+                if info.get("state") == "open":
+                    open_ports.append(port)
+        score = -len(open_ports)
+        return {"category": "ports", "score": score, "details": {"open_ports": open_ports}}
+    except Exception as exc:  # スキャン失敗時
+        return {"category": "ports", "score": 0, "details": {"error": str(exc)}}

--- a/src/scans/smb_netbios.py
+++ b/src/scans/smb_netbios.py
@@ -1,0 +1,14 @@
+"""SMB/NetBIOS checks using Scapy."""
+
+from scapy.all import srp, Ether, IP  # type: ignore
+
+
+def scan(target: str) -> dict:
+    """Placeholder SMB/NetBIOS scan."""
+    try:
+        # 実際の通信は後で実装予定
+        _ = (srp, Ether, IP)  # 参照して未使用警告を抑制
+        details = {"hosts": []}
+        return {"category": "smb_netbios", "score": 0, "details": details}
+    except Exception as exc:
+        return {"category": "smb_netbios", "score": 0, "details": {"error": str(exc)}}

--- a/src/scans/ssl_cert.py
+++ b/src/scans/ssl_cert.py
@@ -1,0 +1,16 @@
+"""SSL certificate inspection."""
+
+import ssl
+import socket
+
+
+def scan(host: str, port: int = 443) -> dict:
+    """Fetch SSL certificate details from a host."""
+    context = ssl.create_default_context()
+    try:
+        with socket.create_connection((host, port), timeout=3) as sock:
+            with context.wrap_socket(sock, server_hostname=host) as ssock:
+                cert = ssock.getpeercert()
+        return {"category": "ssl_cert", "score": 0, "details": {"subject": cert.get("subject")}}
+    except Exception as exc:
+        return {"category": "ssl_cert", "score": 0, "details": {"error": str(exc)}}

--- a/src/scans/upnp.py
+++ b/src/scans/upnp.py
@@ -1,0 +1,13 @@
+"""UPnP discovery using SSDP."""
+
+from scapy.all import IP, UDP, Raw, sr1  # type: ignore
+
+
+def scan(target: str = "239.255.255.250") -> dict:
+    """Discover UPnP devices via SSDP broadcast."""
+    try:
+        _ = (IP, UDP, Raw, sr1)  # 実際の処理は未実装
+        details = {"devices": []}
+        return {"category": "upnp", "score": 0, "details": details}
+    except Exception as exc:
+        return {"category": "upnp", "score": 0, "details": {"error": str(exc)}}

--- a/tests/test_port_scan.py
+++ b/tests/test_port_scan.py
@@ -2,6 +2,7 @@ import nmap
 import pytest
 from src.port_scan import scan_ports
 
+
 def test_scan_ports_returns_only_open_ports(monkeypatch):
     fake_result = {
         "scan": {
@@ -45,6 +46,8 @@ def test_scan_ports_all_closed_ports(monkeypatch):
 
     result = scan_ports("127.0.0.1")
     assert result == []
+
+
 def test_scan_ports_handles_scan_errors(monkeypatch):
     class ErrorScanner:
         def scan(self, target_ip, arguments=""):

--- a/tests/test_ports_functionality.py
+++ b/tests/test_ports_functionality.py
@@ -1,0 +1,23 @@
+import threading
+import time
+from http.server import HTTPServer, SimpleHTTPRequestHandler
+
+from src.scans import ports
+from src import port_scan
+
+
+def test_port_scans_detect_open_port():
+    server = HTTPServer(("0.0.0.0", 80), SimpleHTTPRequestHandler)
+    thread = threading.Thread(target=server.serve_forever)
+    thread.daemon = True
+    thread.start()
+    try:
+        time.sleep(0.2)  # allow server to start
+        result_module = ports.scan("127.0.0.1")
+        assert 80 in result_module["details"].get("open_ports", [])
+
+        result_util = port_scan.scan_ports("127.0.0.1")
+        assert 80 in result_util
+    finally:
+        server.shutdown()
+        thread.join()

--- a/tests/test_scans_modules.py
+++ b/tests/test_scans_modules.py
@@ -1,0 +1,20 @@
+from src.scans import ports, os_banner, smb_netbios, upnp, arp_spoof, dhcp, dns, ssl_cert
+
+
+def test_scan_modules_return_unified_dict():
+    modules = [
+        (ports.scan, {"target": "127.0.0.1"}),
+        (os_banner.scan, {"target": "127.0.0.1"}),
+        (smb_netbios.scan, {"target": "127.0.0.1"}),
+        (upnp.scan, {}),
+        (arp_spoof.scan, {}),
+        (dhcp.scan, {}),
+        (dns.scan, {"name": "example.com"}),
+        (ssl_cert.scan, {"host": "example.com"}),
+    ]
+    for func, kwargs in modules:
+        result = func(**kwargs)
+        assert set(result.keys()) == {"category", "score", "details"}
+        assert isinstance(result["category"], str)
+        assert isinstance(result["score"], int)
+        assert isinstance(result["details"], dict)

--- a/tests/test_ssl_cert_functionality.py
+++ b/tests/test_ssl_cert_functionality.py
@@ -1,0 +1,43 @@
+import ssl
+import socket
+
+from src.scans import ssl_cert
+
+
+class DummySocket:
+    def __enter__(self):
+        return self
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class DummySSLSocket:
+    def __init__(self, cert):
+        self._cert = cert
+    def getpeercert(self):
+        return self._cert
+    def __enter__(self):
+        return self
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+def test_ssl_cert_returns_subject(monkeypatch):
+    cert = {"subject": ((("commonName", "example.com"),),)}
+
+    def fake_create_connection(addr, timeout=3):
+        return DummySocket()
+
+    def fake_wrap_socket(sock, server_hostname=None):
+        return DummySSLSocket(cert)
+
+    class DummyContext:
+        def wrap_socket(self, sock, server_hostname=None):
+            return fake_wrap_socket(sock, server_hostname)
+
+    monkeypatch.setattr(socket, "create_connection", fake_create_connection)
+    monkeypatch.setattr(ssl, "create_default_context", lambda: DummyContext())
+
+    result = ssl_cert.scan("example.com")
+    assert result["details"]["subject"] == cert["subject"]
+


### PR DESCRIPTION
## Summary
- implement real port scan logic using nmap
- add placeholder scan modules for ports, OS banner, SMB/NetBIOS, UPnP, ARP spoof, DHCP, DNS and SSL cert checks returning unified dict
- cover new modules with basic structure tests
- expand port and SSL certificate tests to validate detection of open ports and certificate subjects

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892a590ef9083239a237357ca11c3a7