### PR TITLE
Add dynamic packet capture and analysis pipeline

### DIFF
--- a/src/dynamic_scan/analyze.py
+++ b/src/dynamic_scan/analyze.py
@@ -1,0 +1,92 @@
+import asyncio
+import socket
+from datetime import datetime
+from collections import defaultdict
+from typing import Any, Dict, Iterable
+
+import requests
+
+# 危険とされるプロトコルの名称
+DANGEROUS_PROTOCOLS = {"telnet", "ftp", "rdp"}
+
+
+def geoip_lookup(ip: str) -> Dict[str, Any]:
+    """GeoIP 情報を取得する。
+    外部 API を利用し、取得できない場合は空 dict を返す。
+    """
+    try:
+        response = requests.get(f"https://ipapi.co/{ip}/json/", timeout=5)
+        if response.ok:
+            data = response.json()
+            return {"country": data.get("country_name"), "ip": ip}
+    except Exception:
+        pass
+    return {}
+
+
+def reverse_dns_lookup(ip: str) -> str | None:
+    """DNS 逆引きを行い、ホスト名を返す。失敗時は None。"""
+    try:
+        return socket.gethostbyaddr(ip)[0]
+    except Exception:
+        return None
+
+
+def is_dangerous_protocol(protocol: str) -> bool:
+    """危険プロトコルか判定する。"""
+    return protocol.lower() in DANGEROUS_PROTOCOLS
+
+
+def is_unapproved_device(mac: str, approved_macs: Iterable[str]) -> bool:
+    """未承認デバイス (MACアドレス) か判定する。"""
+    return mac not in set(approved_macs)
+
+
+def detect_traffic_anomaly(traffic_stats: Dict[str, int], key: str, size: int, threshold: int = 1_000_000) -> bool:
+    """通信量を集計し、閾値を超えた場合に異常とみなす。"""
+    traffic_stats[key] += size
+    return traffic_stats[key] > threshold
+
+
+def is_night_traffic(timestamp: float, start_hour: int = 0, end_hour: int = 6) -> bool:
+    """深夜帯の通信か判定する。"""
+    hour = datetime.fromtimestamp(timestamp).hour
+    return start_hour <= hour < end_hour
+
+
+async def analyse_packets(queue: asyncio.Queue, storage, approved_macs: Iterable[str] | None = None) -> None:
+    """キューからパケットを取得し解析する。"""
+    approved = set(approved_macs or [])
+    traffic_stats: Dict[str, int] = defaultdict(int)
+
+    while True:
+        packet = await queue.get()
+
+        src_ip = getattr(packet, "src_ip", getattr(packet, "ip_src", None))
+        dst_ip = getattr(packet, "dst_ip", getattr(packet, "ip_dst", None))
+        protocol = getattr(packet, "protocol", getattr(getattr(packet, "payload", None), "name", "unknown"))
+        mac = getattr(packet, "src_mac", getattr(packet, "mac", getattr(packet, "src", "")))
+        size = getattr(packet, "size", getattr(packet, "len", 0))
+        timestamp = getattr(packet, "timestamp", getattr(packet, "time", datetime.now().timestamp()))
+
+        geoip = await asyncio.to_thread(geoip_lookup, src_ip) if src_ip else {}
+        dns = reverse_dns_lookup(src_ip) if src_ip else None
+        dangerous = is_dangerous_protocol(protocol)
+        unapproved = is_unapproved_device(mac, approved)
+        anomaly = detect_traffic_anomaly(traffic_stats, src_ip or mac, size)
+        night = is_night_traffic(timestamp)
+
+        result = {
+            "src_ip": src_ip,
+            "dst_ip": dst_ip,
+            "protocol": protocol,
+            "geoip": geoip,
+            "reverse_dns": dns,
+            "dangerous_protocol": dangerous,
+            "unapproved_device": unapproved,
+            "traffic_anomaly": anomaly,
+            "night_traffic": night,
+        }
+
+        await storage.save(result)
+        queue.task_done()

--- a/src/dynamic_scan/capture.py
+++ b/src/dynamic_scan/capture.py
@@ -1,0 +1,30 @@
+import asyncio
+from scapy.all import AsyncSniffer
+
+
+async def capture_packets(queue: asyncio.Queue, interface: str | None = None, duration: int | None = None) -> None:
+    """Capture packets using Scapy and put them onto the provided queue.
+
+    Parameters
+    ----------
+    queue: asyncio.Queue
+        Queue used to pass packets to the analyser.
+    interface: str | None, optional
+        Network interface to sniff on. Defaults to Scapy's default interface.
+    duration: int | None, optional
+        Number of seconds to run the sniffer. If ``None`` the sniffer runs
+        indefinitely until cancelled.
+    """
+
+    def _enqueue(packet):
+        queue.put_nowait(packet)
+
+    sniffer = AsyncSniffer(iface=interface, prn=_enqueue)
+    sniffer.start()
+    try:
+        if duration is None:
+            await asyncio.Event().wait()  # Run until cancelled
+        else:
+            await asyncio.sleep(duration)
+    finally:
+        sniffer.stop()

--- a/src/dynamic_scan/storage.py
+++ b/src/dynamic_scan/storage.py
@@ -1,0 +1,23 @@
+import json
+import asyncio
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+class Storage:
+    """解析結果を JSON 形式で保持するストレージ層"""
+
+    def __init__(self, file_path: str = "dynamic_scan_results.json") -> None:
+        self.path = Path(file_path)
+        if not self.path.exists():
+            self.path.write_text("[]", encoding="utf-8")
+        self._lock = asyncio.Lock()
+
+    async def save(self, data: Dict[str, Any]) -> None:
+        async with self._lock:
+            current: List[Dict[str, Any]] = json.loads(self.path.read_text(encoding="utf-8"))
+            current.append(data)
+            self.path.write_text(json.dumps(current), encoding="utf-8")
+
+    def get_all(self) -> List[Dict[str, Any]]:
+        return json.loads(self.path.read_text(encoding="utf-8"))

--- a/tests/test_dynamic_scan.py
+++ b/tests/test_dynamic_scan.py
@@ -1,0 +1,108 @@
+import asyncio
+from datetime import datetime
+import contextlib
+from types import SimpleNamespace
+from collections import defaultdict
+
+import pytest
+
+from src.dynamic_scan import analyze, capture, storage
+
+
+def test_geoip_lookup(monkeypatch):
+    class FakeResp:
+        ok = True
+
+        def json(self):
+            return {"country_name": "Wonderland"}
+
+    monkeypatch.setattr(analyze.requests, "get", lambda url, timeout=5: FakeResp())
+    assert analyze.geoip_lookup("203.0.113.1") == {"country": "Wonderland", "ip": "203.0.113.1"}
+
+
+def test_reverse_dns_lookup(monkeypatch):
+    monkeypatch.setattr(analyze.socket, "gethostbyaddr", lambda ip: ("host.example", [], []))
+    assert analyze.reverse_dns_lookup("1.1.1.1") == "host.example"
+
+
+def test_is_dangerous_protocol():
+    assert analyze.is_dangerous_protocol("telnet")
+    assert not analyze.is_dangerous_protocol("http")
+
+
+def test_is_unapproved_device():
+    assert analyze.is_unapproved_device("00:aa", {"00:bb"})
+    assert not analyze.is_unapproved_device("00:aa", {"00:aa"})
+
+
+def test_detect_traffic_anomaly():
+    stats = defaultdict(int)
+    assert analyze.detect_traffic_anomaly(stats, "host", 500_000, threshold=1_000_000) is False
+    assert analyze.detect_traffic_anomaly(stats, "host", 600_000, threshold=1_000_000) is True
+
+
+def test_is_night_traffic():
+    night_ts = datetime(2024, 1, 1, 3, 0).timestamp()
+    day_ts = datetime(2024, 1, 1, 7, 0).timestamp()
+    assert analyze.is_night_traffic(night_ts)
+    assert not analyze.is_night_traffic(day_ts)
+
+
+def test_capture_packets_enqueue(monkeypatch):
+    class FakeSniffer:
+        def __init__(self, iface=None, prn=None):
+            self.prn = prn
+
+        def start(self):
+            self.prn("pkt")
+
+        def stop(self):
+            pass
+
+    monkeypatch.setattr(capture, "AsyncSniffer", FakeSniffer)
+    queue: asyncio.Queue = asyncio.Queue()
+    asyncio.run(capture.capture_packets(queue, duration=0))
+    assert queue.get_nowait() == "pkt"
+
+
+def test_storage_save_and_get(tmp_path):
+    async def runner():
+        store = storage.Storage(tmp_path / "r.json")
+        await store.save({"a": 1})
+        await store.save({"b": 2})
+        assert store.get_all() == [{"a": 1}, {"b": 2}]
+
+    asyncio.run(runner())
+
+
+def test_analyse_packets_pipeline(tmp_path, monkeypatch):
+    async def runner():
+        store = storage.Storage(tmp_path / "results.json")
+        monkeypatch.setattr(analyze, "geoip_lookup", lambda ip: {"country": "Testland", "ip": ip})
+        monkeypatch.setattr(analyze, "reverse_dns_lookup", lambda ip: "example.com")
+        queue: asyncio.Queue = asyncio.Queue()
+        task = asyncio.create_task(
+            analyze.analyse_packets(queue, store, approved_macs={"00:11:22:33:44:55"})
+        )
+        pkt = SimpleNamespace(
+            src_ip="8.8.8.8",
+            dst_ip="1.1.1.1",
+            src_mac="00:11:22:33:44:66",
+            protocol="TELNET",
+            size=2_000_000,
+            timestamp=datetime(2024, 1, 1, 2, 0, 0).timestamp(),
+        )
+        await queue.put(pkt)
+        await queue.join()
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+        data = store.get_all()
+        assert data[0]["dangerous_protocol"] is True
+        assert data[0]["unapproved_device"] is True
+        assert data[0]["traffic_anomaly"] is True
+        assert data[0]["night_traffic"] is True
+        assert data[0]["geoip"]["country"] == "Testland"
+        assert data[0]["reverse_dns"] == "example.com"
+
+    asyncio.run(runner())


### PR DESCRIPTION
## Summary
- add asynchronous packet capture using Scapy
- analyse packets for GeoIP, DNS, dangerous protocols, unapproved devices and anomalies
- persist analysis results to JSON storage and expose a test covering the pipeline
- add thorough unit tests for capture, analysis helpers and storage persistence

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892b40c9798832396a39355ce2c2b01