### PR TITLE
Add dynamic scan API and realtime WebSocket feed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,6 @@ scapy
 geoip2
 pdfkit
 pytest
+fastapi
+uvicorn
+httpx

--- a/src/api.py
+++ b/src/api.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import asyncio
+import os
+from contextlib import suppress
+from typing import Optional
+
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect, Depends, Header, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+
+from .dynamic_scan import capture, analyze, storage
+
+app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+API_TOKEN = os.getenv("API_TOKEN")
+
+
+async def verify_token(authorization: str | None = Header(default=None)) -> None:
+    if API_TOKEN and authorization != f"Bearer {API_TOKEN}":
+        raise HTTPException(status_code=401, detail="Unauthorized")
+
+
+class StartParams(BaseModel):
+    interface: Optional[str] = None
+    duration: Optional[int] = None
+    approved_macs: Optional[list[str]] = None
+
+
+scan_queue: asyncio.Queue | None = None
+capture_task: asyncio.Task | None = None
+analyse_task: asyncio.Task | None = None
+storage_obj = storage.Storage()
+
+
+@app.post("/scan/dynamic/start")
+async def start_scan(params: StartParams, _: None = Depends(verify_token)):
+    global scan_queue, capture_task, analyse_task, storage_obj
+    if capture_task or analyse_task:
+        return {"status": "already_running"}
+    scan_queue = asyncio.Queue()
+    storage_obj = storage.Storage()
+    capture_task = asyncio.create_task(
+        capture.capture_packets(
+            scan_queue,
+            interface=params.interface,
+            duration=params.duration,
+        )
+    )
+    analyse_task = asyncio.create_task(
+        analyze.analyse_packets(
+            scan_queue,
+            storage_obj,
+            approved_macs=params.approved_macs or [],
+        )
+    )
+    return {"status": "started"}
+
+
+@app.post("/scan/dynamic/stop")
+async def stop_scan(_: None = Depends(verify_token)):
+    global capture_task, analyse_task
+    for task in (capture_task, analyse_task):
+        if task:
+            task.cancel()
+            with suppress(asyncio.CancelledError):
+                await task
+    capture_task = analyse_task = None
+    return {"status": "stopped"}
+
+
+@app.get("/scan/dynamic/results")
+async def get_results(_: None = Depends(verify_token)):
+    return {"results": storage_obj.get_all()}
+
+
+@app.websocket("/ws/scan/dynamic")
+async def ws_dynamic_scan(websocket: WebSocket):
+    await websocket.accept()
+    queue: asyncio.Queue = asyncio.Queue()
+    storage_obj.add_listener(queue)
+    try:
+        while True:
+            data = await queue.get()
+            await websocket.send_json(data)
+    except WebSocketDisconnect:
+        pass
+    finally:
+        storage_obj.remove_listener(queue)
+

--- a/src/dynamic_scan/storage.py
+++ b/src/dynamic_scan/storage.py
@@ -12,12 +12,24 @@ class Storage:
         if not self.path.exists():
             self.path.write_text("[]", encoding="utf-8")
         self._lock = asyncio.Lock()
+        self._listeners: List[asyncio.Queue] = []
+
+    def add_listener(self, queue: asyncio.Queue) -> None:
+        """結果更新時に通知を受け取るキューを追加"""
+        self._listeners.append(queue)
+
+    def remove_listener(self, queue: asyncio.Queue) -> None:
+        """通知キューを削除"""
+        if queue in self._listeners:
+            self._listeners.remove(queue)
 
     async def save(self, data: Dict[str, Any]) -> None:
         async with self._lock:
             current: List[Dict[str, Any]] = json.loads(self.path.read_text(encoding="utf-8"))
             current.append(data)
             self.path.write_text(json.dumps(current), encoding="utf-8")
+        for q in list(self._listeners):
+            q.put_nowait(data)
 
     def get_all(self) -> List[Dict[str, Any]]:
         return json.loads(self.path.read_text(encoding="utf-8"))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,42 @@
+import asyncio
+from fastapi.testclient import TestClient
+
+from src import api
+from src.dynamic_scan import capture, analyze, storage
+
+
+def test_dynamic_scan_start_stop(monkeypatch, tmp_path):
+    client = TestClient(api.app)
+    api.storage_obj = storage.Storage(tmp_path / "res.json")
+
+    async def dummy_capture(queue, interface=None, duration=None):
+        return
+
+    async def dummy_analyse(queue, storage_obj, approved_macs=None):
+        return
+
+    monkeypatch.setattr(capture, "capture_packets", dummy_capture)
+    monkeypatch.setattr(analyze, "analyse_packets", dummy_analyse)
+
+    resp = client.post("/scan/dynamic/start", json={"duration": 0})
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "started"
+
+    resp2 = client.post("/scan/dynamic/stop")
+    assert resp2.status_code == 200
+    assert resp2.json()["status"] == "stopped"
+
+    asyncio.run(api.storage_obj.save({"key": "value"}))
+    resp3 = client.get("/scan/dynamic/results")
+    assert resp3.json()["results"] == [{"key": "value"}]
+
+
+def test_dynamic_scan_websocket_broadcast(tmp_path):
+    client = TestClient(api.app)
+    api.storage_obj = storage.Storage(tmp_path / "res.json")
+
+    with client.websocket_connect("/ws/scan/dynamic") as websocket:
+        # 保存すると WebSocket へプッシュされることを確認
+        asyncio.run(api.storage_obj.save({"foo": "bar"}))
+        message = websocket.receive_json()
+        assert message == {"foo": "bar"}


### PR DESCRIPTION
## Summary
- expose dynamic scan control and result endpoints via FastAPI
- broadcast scan results to WebSocket listeners and persist JSON
- cover API start/stop/results and WebSocket broadcasting via tests

## Testing
- `bash setup.sh`
- `bash flutter_env.sh` *(fails: flutter: command not found)*
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892bae7eea8832399533ac3eaa9826c