### PR TITLE
Add static scan aggregator with modular scans

### DIFF
--- a/src/scans/__init__.py
+++ b/src/scans/__init__.py
@@ -1,0 +1,1 @@
+"""Collection of static network scan modules."""

--- a/src/scans/arp_spoof.py
+++ b/src/scans/arp_spoof.py
@@ -1,0 +1,9 @@
+"""Static scan for ARP spoofing detection."""
+
+from typing import Dict, Any
+
+
+def scan() -> Dict[str, Any]:
+    """Return dummy ARP spoofing data."""
+    # 実際のARPスプーフィング検出は未実装
+    return {"category": "arp_spoof", "score": 0, "details": {"alerts": []}}

--- a/src/scans/dhcp.py
+++ b/src/scans/dhcp.py
@@ -1,0 +1,9 @@
+"""Static scan for DHCP configuration."""
+
+from typing import Dict, Any
+
+
+def scan() -> Dict[str, Any]:
+    """Return dummy DHCP data."""
+    # 実際のDHCP解析は未実装
+    return {"category": "dhcp", "score": 0, "details": {"servers": []}}

--- a/src/scans/dns.py
+++ b/src/scans/dns.py
@@ -1,0 +1,9 @@
+"""Static scan for DNS records."""
+
+from typing import Dict, Any
+
+
+def scan() -> Dict[str, Any]:
+    """Return dummy DNS data."""
+    # 実際のDNS解析は未実装
+    return {"category": "dns", "score": 0, "details": {"records": []}}

--- a/src/scans/os_banner.py
+++ b/src/scans/os_banner.py
@@ -1,0 +1,9 @@
+"""Static scan for OS banners."""
+
+from typing import Dict, Any
+
+
+def scan() -> Dict[str, Any]:
+    """Return dummy OS banner data."""
+    # 実際のOS判別は未実装
+    return {"category": "os_banner", "score": 0, "details": {"banners": []}}

--- a/src/scans/ports.py
+++ b/src/scans/ports.py
@@ -1,0 +1,9 @@
+"""Static scan for open ports."""
+
+from typing import Dict, Any
+
+
+def scan() -> Dict[str, Any]:
+    """Return dummy port scan data."""
+    # 実際のポートスキャンは未実装
+    return {"category": "ports", "score": 0, "details": {"open_ports": []}}

--- a/src/scans/smb_netbios.py
+++ b/src/scans/smb_netbios.py
@@ -1,0 +1,9 @@
+"""Static scan for SMB/NetBIOS information."""
+
+from typing import Dict, Any
+
+
+def scan() -> Dict[str, Any]:
+    """Return dummy SMB/NetBIOS data."""
+    # 実際のSMB/NetBIOS検出は未実装
+    return {"category": "smb_netbios", "score": 0, "details": {"hosts": []}}

--- a/src/scans/ssl_cert.py
+++ b/src/scans/ssl_cert.py
@@ -1,0 +1,9 @@
+"""Static scan for SSL certificate validation."""
+
+from typing import Dict, Any
+
+
+def scan() -> Dict[str, Any]:
+    """Return dummy SSL certificate data."""
+    # 実際のSSL証明書検証は未実装
+    return {"category": "ssl_cert", "score": 0, "details": {"certificates": []}}

--- a/src/scans/upnp.py
+++ b/src/scans/upnp.py
@@ -1,0 +1,9 @@
+"""Static scan for UPnP services."""
+
+from typing import Dict, Any
+
+
+def scan() -> Dict[str, Any]:
+    """Return dummy UPnP data."""
+    # 実際のUPnP検出は未実装
+    return {"category": "upnp", "score": 0, "details": {"services": []}}

--- a/src/static_scan.py
+++ b/src/static_scan.py
@@ -1,0 +1,37 @@
+"""Aggregate multiple static network scan modules."""
+
+from concurrent.futures import ThreadPoolExecutor
+from typing import Dict, Any
+
+from .scans import (
+    ports,
+    os_banner,
+    smb_netbios,
+    upnp,
+    arp_spoof,
+    dhcp,
+    dns,
+    ssl_cert,
+)
+
+SCANNERS = [
+    ports.scan,
+    os_banner.scan,
+    smb_netbios.scan,
+    upnp.scan,
+    arp_spoof.scan,
+    dhcp.scan,
+    dns.scan,
+    ssl_cert.scan,
+]
+
+
+def run_all() -> Dict[str, Dict[str, Any]]:
+    """Run all static scans concurrently and aggregate their results."""
+    with ThreadPoolExecutor() as executor:
+        futures = [executor.submit(scanner) for scanner in SCANNERS]
+        results = [future.result() for future in futures]
+
+    # Combine results using category as key
+    combined: Dict[str, Dict[str, Any]] = {res["category"]: res for res in results}
+    return combined

--- a/tests/test_static_scan.py
+++ b/tests/test_static_scan.py
@@ -1,0 +1,51 @@
+from src import static_scan
+from src.scans import (
+    ports,
+    os_banner,
+    smb_netbios,
+    upnp,
+    arp_spoof,
+    dhcp,
+    dns,
+    ssl_cert,
+)
+import pytest
+
+
+def test_run_all_returns_all_categories():
+    results = static_scan.run_all()
+    expected = {
+        "ports",
+        "os_banner",
+        "smb_netbios",
+        "upnp",
+        "arp_spoof",
+        "dhcp",
+        "dns",
+        "ssl_cert",
+    }
+    assert set(results.keys()) == expected
+    for category, data in results.items():
+        assert data["category"] == category
+        assert isinstance(data["score"], int)
+        assert isinstance(data["details"], dict)
+
+
+@pytest.mark.parametrize(
+    "module,category",
+    [
+        (ports, "ports"),
+        (os_banner, "os_banner"),
+        (smb_netbios, "smb_netbios"),
+        (upnp, "upnp"),
+        (arp_spoof, "arp_spoof"),
+        (dhcp, "dhcp"),
+        (dns, "dns"),
+        (ssl_cert, "ssl_cert"),
+    ],
+)
+def test_individual_scans_return_structured_data(module, category):
+    result = module.scan()
+    assert result["category"] == category
+    assert isinstance(result["score"], int)
+    assert isinstance(result["details"], dict)


### PR DESCRIPTION
## Summary
- implement `static_scan.run_all` to execute multiple scan modules concurrently and merge their results
- add modular scan stubs for ports, OS banner, SMB/NetBIOS, UPnP, ARP spoofing, DHCP, DNS and SSL certificate
- cover static scan aggregation and individual scan outputs with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892bdc7572c8323b4c710adefab2ddd