### PR TITLE
feat: add static scan endpoint

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import asyncio
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+import static_scan
+
+STATIC_SCAN_TIMEOUT = 60  # seconds
+
+app = FastAPI()
+
+@app.get('/static_scan')
+async def static_scan_endpoint():
+    try:
+        result = await asyncio.wait_for(asyncio.to_thread(static_scan.run_all), timeout=STATIC_SCAN_TIMEOUT)
+    except asyncio.TimeoutError:
+        return JSONResponse(status_code=504, content={
+            'status': 'timeout',
+            'message': 'Static scan timed out'
+        })
+    except Exception as exc:  # pylint: disable=broad-except
+        return JSONResponse(status_code=500, content={
+            'status': 'error',
+            'message': f'Static scan failed: {exc}'
+        })
+
+    findings = result.get('findings', {}) if isinstance(result, dict) else result
+    risk_score = result.get('risk_score') if isinstance(result, dict) else None
+    return {'status': 'ok', 'findings': findings, 'risk_score': risk_score}

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,74 @@
+import sys
+import time
+import types
+import importlib
+
+from fastapi.testclient import TestClient
+
+
+def _import_server(monkeypatch, run_all):
+    module = types.ModuleType('static_scan')
+    module.run_all = run_all
+    monkeypatch.setitem(sys.modules, 'static_scan', module)
+    from src import server
+    importlib.reload(server)
+    return server
+
+
+def test_static_scan_success(monkeypatch):
+    def fake_run_all():
+        return {'findings': {'ports': ['22']}, 'risk_score': 5}
+
+    server = _import_server(monkeypatch, fake_run_all)
+    client = TestClient(server.app)
+
+    resp = client.get('/static_scan')
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data['status'] == 'ok'
+    assert data['findings']['ports'] == ['22']
+    assert data['risk_score'] == 5
+
+
+def test_static_scan_timeout(monkeypatch):
+    def slow_run_all():
+        time.sleep(0.2)
+
+    server = _import_server(monkeypatch, slow_run_all)
+    monkeypatch.setattr(server, 'STATIC_SCAN_TIMEOUT', 0.05)
+    client = TestClient(server.app)
+
+    resp = client.get('/static_scan')
+    assert resp.status_code == 504
+    assert resp.json()['status'] == 'timeout'
+
+
+def test_static_scan_error(monkeypatch):
+    def bad_run_all():
+        raise RuntimeError('boom')
+
+    server = _import_server(monkeypatch, bad_run_all)
+    client = TestClient(server.app)
+
+    resp = client.get('/static_scan')
+    assert resp.status_code == 500
+    body = resp.json()
+    assert body['status'] == 'error'
+    assert 'boom' in body['message']
+
+
+def test_static_scan_non_dict(monkeypatch):
+    """run_allが辞書以外を返した場合のハンドリングを確認"""
+
+    def weird_run_all():
+        return ['80/tcp open http']
+
+    server = _import_server(monkeypatch, weird_run_all)
+    client = TestClient(server.app)
+
+    resp = client.get('/static_scan')
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data['status'] == 'ok'
+    assert data['findings'] == ['80/tcp open http']
+    assert data['risk_score'] is None


### PR DESCRIPTION
## Summary
- add FastAPI server exposing `/static_scan`
- handle scan timeouts and errors
- test static scan API success, timeout, failure, and non-dict result cases

## Testing
- `pytest`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892c18c2f008323b9f6f5f42ef39391