### PR TITLE
chore: add fake_async for testing

### DIFF
--- a/nw_checker/pubspec.yaml
+++ b/nw_checker/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  fake_async: ^1.3.1
 
   # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is


### PR DESCRIPTION
## Summary
- add `fake_async` dev dependency

## Testing
- `flutter pub get`
- `flutter test`
- `source nw_checker/.venv/bin/activate && pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892d4233fa08323a6c10e58e65e7532