### PR TITLE
Add scan report models and dynamic results UI

### DIFF
--- a/nw_checker/lib/dynamic_scan_tab.dart
+++ b/nw_checker/lib/dynamic_scan_tab.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'models/scan_category.dart';
+import 'models/scan_report.dart';
 import 'services/dynamic_scan_api.dart';
 
 /// 動的スキャンタブのウィジェット。
@@ -10,7 +12,8 @@ class DynamicScanTab extends StatefulWidget {
 }
 
 class _DynamicScanTabState extends State<DynamicScanTab> {
-  Stream<List<String>>? _resultStream;
+  Stream<ScanReport>? _resultStream;
+  ScanReport? _latestReport;
   bool _isScanning = false;
 
   Future<void> _startScan() async {
@@ -27,6 +30,12 @@ class _DynamicScanTabState extends State<DynamicScanTab> {
       _isScanning = false;
       _resultStream = null;
     });
+  }
+
+  void _exportPdf() {
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(const SnackBar(content: Text('PDF export not implemented')));
   }
 
   @override
@@ -53,22 +62,57 @@ class _DynamicScanTabState extends State<DynamicScanTab> {
             child: CircularProgressIndicator(),
           ),
         Expanded(
-          child: StreamBuilder<List<String>>(
+          child: StreamBuilder<ScanReport>(
             stream: _resultStream,
             builder: (context, snapshot) {
-              final results = snapshot.data ?? [];
-              if (results.isEmpty) {
+              if (snapshot.hasData) {
+                _latestReport = snapshot.data;
+              }
+              final report = _latestReport;
+              if (report == null) {
                 return const SizedBox.shrink();
               }
-              return ListView.builder(
-                itemCount: results.length,
-                itemBuilder:
-                    (context, index) => ListTile(title: Text(results[index])),
+              return Column(
+                children: [
+                  _buildSummary(report),
+                  Expanded(child: _buildCategoryList(report.categories)),
+                ],
               );
             },
           ),
         ),
       ],
+    );
+  }
+
+  Widget _buildSummary(ScanReport report) {
+    return Card(
+      margin: const EdgeInsets.all(8),
+      child: ListTile(
+        title: Text('Risk Score: ${report.riskScore}'),
+        trailing: ElevatedButton.icon(
+          onPressed: _exportPdf,
+          icon: const Icon(Icons.picture_as_pdf),
+          label: const Text('Export PDF'),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildCategoryList(List<ScanCategory> categories) {
+    return ListView(
+      children:
+          categories.map((cat) {
+            return ExpansionTile(
+              leading: Icon(
+                categoryIcon(cat.name),
+                color: severityColor(cat.severity),
+              ),
+              title: Text(cat.name),
+              children:
+                  cat.issues.map((e) => ListTile(title: Text(e))).toList(),
+            );
+          }).toList(),
     );
   }
 }

--- a/nw_checker/lib/models/scan_category.dart
+++ b/nw_checker/lib/models/scan_category.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+
+/// スキャン結果のカテゴリ。
+class ScanCategory {
+  final String name;
+  final Severity severity;
+  final List<String> issues;
+
+  ScanCategory({
+    required this.name,
+    required this.severity,
+    required this.issues,
+  });
+
+  factory ScanCategory.fromJson(Map<String, dynamic> json) {
+    return ScanCategory(
+      name: json['name'] as String,
+      severity: severityFromString(json['severity'] as String? ?? ''),
+      issues: (json['issues'] as List<dynamic>? ?? []).cast<String>(),
+    );
+  }
+}
+
+/// 危険度。
+enum Severity { low, medium, high }
+
+/// 文字列から危険度へ変換。
+Severity severityFromString(String value) {
+  switch (value.toLowerCase()) {
+    case 'high':
+      return Severity.high;
+    case 'medium':
+      return Severity.medium;
+    case 'low':
+    default:
+      return Severity.low;
+  }
+}
+
+/// 危険度に応じた色を返す。
+Color severityColor(Severity severity) {
+  switch (severity) {
+    case Severity.high:
+      return Colors.red;
+    case Severity.medium:
+      return Colors.orange;
+    case Severity.low:
+      return Colors.green;
+  }
+}
+
+/// カテゴリ名に応じたアイコンを返す。
+IconData categoryIcon(String name) {
+  switch (name.toLowerCase()) {
+    case 'ports':
+      return Icons.router;
+    case 'smb':
+      return Icons.folder_shared;
+    case 'dns':
+      return Icons.language;
+    default:
+      return Icons.security;
+  }
+}

--- a/nw_checker/lib/models/scan_report.dart
+++ b/nw_checker/lib/models/scan_report.dart
@@ -1,0 +1,20 @@
+import 'scan_category.dart';
+
+/// スキャンレポート全体。
+class ScanReport {
+  final int riskScore;
+  final List<ScanCategory> categories;
+
+  ScanReport({required this.riskScore, required this.categories});
+
+  factory ScanReport.fromJson(Map<String, dynamic> json) {
+    final cats =
+        (json['categories'] as List<dynamic>? ?? [])
+            .map((e) => ScanCategory.fromJson(e as Map<String, dynamic>))
+            .toList();
+    return ScanReport(
+      riskScore: json['riskScore'] as int? ?? 0,
+      categories: cats,
+    );
+  }
+}

--- a/nw_checker/lib/services/dynamic_scan_api.dart
+++ b/nw_checker/lib/services/dynamic_scan_api.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import '../models/scan_report.dart';
 
 /// ダミーの動的スキャンAPI。
 /// 実際のバックエンドとの通信は今後実装予定。
@@ -16,14 +17,33 @@ class DynamicScanApi {
   }
 
   /// スキャン結果をストリームで返す。
-  /// 現状は1秒ごとにダミーデータを追加する。
-  static Stream<List<String>> fetchResults() {
-    final results = <String>[];
-    var count = 1;
-    return Stream.periodic(const Duration(seconds: 1), (_) {
-      results.add('Result line $count');
-      count++;
-      return List<String>.from(results);
-    });
+  /// 現状は1秒後にダミーのJSONをパースして返す。
+  static Stream<ScanReport> fetchResults() {
+    const dummyJson = {
+      'riskScore': 87,
+      'categories': [
+        {
+          'name': 'Ports',
+          'severity': 'high',
+          'issues': ['22/tcp open', '23/tcp open'],
+        },
+        {
+          'name': 'SMB',
+          'severity': 'medium',
+          'issues': ['SMBv1 enabled'],
+        },
+        {
+          'name': 'DNS',
+          'severity': 'low',
+          'issues': ['Zone transfer allowed'],
+        },
+      ],
+    };
+    return Stream.fromFuture(
+      Future.delayed(
+        const Duration(seconds: 1),
+        () => ScanReport.fromJson(dummyJson),
+      ),
+    );
   }
 }

--- a/nw_checker/test/dynamic_scan_api_test.dart
+++ b/nw_checker/test/dynamic_scan_api_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:nw_checker/models/scan_report.dart';
 import 'package:nw_checker/services/dynamic_scan_api.dart';
 
 void main() {
@@ -10,9 +11,12 @@ void main() {
     await expectLater(DynamicScanApi.stopScan(), completes);
   });
 
-  test('fetchResults emits growing lists', () async {
-    final values = await DynamicScanApi.fetchResults().take(2).toList();
-    expect(values[0], ['Result line 1']);
-    expect(values[1], ['Result line 1', 'Result line 2']);
+  test('fetchResults emits report', () async {
+    final reports = await DynamicScanApi.fetchResults().toList();
+    expect(reports, hasLength(1));
+    final report = reports.first;
+    expect(report.riskScore, 87);
+    expect(report.categories.first.name, 'Ports');
+    expect(report.categories.first.issues, contains('22/tcp open'));
   });
 }

--- a/nw_checker/test/dynamic_scan_tab_flow_test.dart
+++ b/nw_checker/test/dynamic_scan_tab_flow_test.dart
@@ -3,9 +3,10 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:nw_checker/dynamic_scan_tab.dart';
 
 void main() {
-  Widget buildWidget() => const MaterialApp(home: Scaffold(body: DynamicScanTab()));
+  Widget buildWidget() =>
+      const MaterialApp(home: Scaffold(body: DynamicScanTab()));
 
-  testWidgets('button tap shows progress then results', (tester) async {
+  testWidgets('button tap shows progress then report', (tester) async {
     await tester.pumpWidget(buildWidget());
 
     await tester.tap(find.text('スキャン開始'));
@@ -14,6 +15,7 @@ void main() {
     expect(find.byType(CircularProgressIndicator), findsOneWidget);
 
     await tester.pump(const Duration(seconds: 1));
-    expect(find.byType(ListView), findsOneWidget);
+    expect(find.text('Risk Score: 87'), findsOneWidget);
+    expect(find.text('Ports'), findsOneWidget);
   });
 }

--- a/nw_checker/test/dynamic_scan_tab_test.dart
+++ b/nw_checker/test/dynamic_scan_tab_test.dart
@@ -13,7 +13,7 @@ void main() {
     expect(find.text('スキャン停止'), findsOneWidget);
   });
 
-  testWidgets('DynamicScanTab streams results and stops', (tester) async {
+  testWidgets('DynamicScanTab streams report and stops', (tester) async {
     await tester.pumpWidget(_buildWidget());
 
     await tester.tap(find.text('スキャン開始'));
@@ -23,14 +23,14 @@ void main() {
     expect(find.byType(CircularProgressIndicator), findsOneWidget);
 
     await tester.pump(const Duration(seconds: 1));
-    expect(find.byType(ListView), findsOneWidget);
-    expect(find.text('Result line 1'), findsOneWidget);
+    expect(find.text('Risk Score: 87'), findsOneWidget);
+    expect(find.text('Ports'), findsOneWidget);
 
     await tester.tap(find.text('スキャン停止'));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 300));
     await tester.pump();
     expect(find.byType(CircularProgressIndicator), findsNothing);
-    expect(find.text('Result line 1'), findsOneWidget);
+    expect(find.text('Risk Score: 87'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- add model classes to parse scan JSON and map severity to color/icon
- show risk score summary with PDF export button and category sections

## Testing
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_6892f2e608448323a1cc5dc5d491ec97