### PR TITLE
Add tests for static scan and static scan widget flow

### DIFF
--- a/nw_checker/test/static_scan_tab_flow_test.dart
+++ b/nw_checker/test/static_scan_tab_flow_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nw_checker/static_scan_tab.dart';
+
+void main() {
+  Widget buildWidget() =>
+      const MaterialApp(home: Scaffold(body: StaticScanTab()));
+
+  testWidgets('button tap shows progress then results', (tester) async {
+    await tester.pumpWidget(buildWidget());
+
+    await tester.tap(find.byKey(const Key('staticButton')));
+    await tester.pump();
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+    await tester.pump(const Duration(seconds: 90));
+    await tester.pump();
+
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+    expect(find.text('=== STATIC SCAN REPORT ==='), findsOneWidget);
+    expect(find.text('No issues detected.'), findsOneWidget);
+  });
+}

--- a/tests/test_static_scan.py
+++ b/tests/test_static_scan.py
@@ -34,6 +34,16 @@ def test_run_all_returns_all_categories():
         assert isinstance(data.severity, str)
 
 
+def test_run_all_propagates_scanner_exception(monkeypatch):
+    def boom():
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(static_scan, "SCANNERS", [boom])
+
+    with pytest.raises(RuntimeError):
+        static_scan.run_all()
+
+
 @pytest.mark.parametrize(
     "module,category",
     [


### PR DESCRIPTION
## Summary
- verify static scan aggregator raises when a module fails
- test Flutter static scan button shows progress then outputs results

## Testing
- `pytest`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892f5b94d0883238fe1d3777a78d7e7