### PR TITLE
Add tests for static scan and static scan widget flow

### DIFF
--- a/nw_checker/lib/static_scan_tab.dart
+++ b/nw_checker/lib/static_scan_tab.dart
@@ -11,7 +11,9 @@ Future<List<String>> performStaticScan() async {
 }
 
 class StaticScanTab extends StatefulWidget {
-  const StaticScanTab({super.key});
+  const StaticScanTab({super.key, this.scanner = performStaticScan});
+
+  final Future<List<String>> Function() scanner;
 
   @override
   State<StaticScanTab> createState() => _StaticScanTabState();
@@ -27,7 +29,7 @@ class _StaticScanTabState extends State<StaticScanTab> {
       _isLoading = true;
       _showOutput = false;
     });
-    performStaticScan().then((lines) {
+    widget.scanner().then((lines) {
       if (!mounted) return;
       setState(() {
         _isLoading = false;

--- a/nw_checker/test/static_scan_tab_flow_test.dart
+++ b/nw_checker/test/static_scan_tab_flow_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nw_checker/static_scan_tab.dart';
+
+void main() {
+  Future<List<String>> mockScan() async =>
+      ['=== STATIC SCAN REPORT ===', 'No issues detected.'];
+
+  Widget buildWidget() => MaterialApp(
+        home: Scaffold(body: StaticScanTab(scanner: mockScan)),
+      );
+
+  testWidgets('button tap shows progress then results', (tester) async {
+    await tester.pumpWidget(buildWidget());
+
+    await tester.tap(find.byKey(const Key('staticButton')));
+    await tester.pump();
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+    await tester.pumpAndSettle();
+
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+    expect(find.text('=== STATIC SCAN REPORT ==='), findsOneWidget);
+    expect(find.text('No issues detected.'), findsOneWidget);
+  });
+}

--- a/tests/test_static_scan.py
+++ b/tests/test_static_scan.py
@@ -34,6 +34,16 @@ def test_run_all_returns_all_categories():
         assert isinstance(data.severity, str)
 
 
+def test_run_all_propagates_scanner_exception(monkeypatch):
+    def boom():
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(static_scan, "SCANNERS", [boom])
+
+    with pytest.raises(RuntimeError):
+        static_scan.run_all()
+
+
 @pytest.mark.parametrize(
     "module,category",
     [


### PR DESCRIPTION
## Summary
- verify static scan aggregator raises when a module fails
- mock static scan tab backend to test loading indicator and results

## Testing
- `pytest`
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892f5b94d0883238fe1d3777a78d7e7