### PR TITLE
feat: add network scan modules

### DIFF
--- a/src/scans/arp_spoof.py
+++ b/src/scans/arp_spoof.py
@@ -1,10 +1,29 @@
-"""Static scan for ARP spoofing attempts."""
+"""Static scan for ARP spoofing attempts using scapy."""
 
-from ..models import ScanResult
+from scapy.all import sniff, ARP  # type: ignore
 
 
-def scan() -> ScanResult:
-    """Return dummy ARP spoofing data."""
-    severity = "low"
-    message = "No ARP spoofing detected."
-    return ScanResult.from_severity(category="arp_spoof", message=message, severity=severity)
+def scan(timeout: int = 2) -> dict:
+    """Sniff ARP replies briefly and look for conflicting MAC addresses."""
+
+    suspects = set()
+    try:
+        packets = sniff(filter="arp", timeout=timeout)
+        seen = {}
+        for pkt in packets:
+            if ARP in pkt and pkt[ARP].op == 2:  # is-at
+                ip = pkt[ARP].psrc
+                mac = pkt[ARP].hwsrc
+                if ip in seen and seen[ip] != mac:
+                    suspects.add(ip)
+                else:
+                    seen[ip] = mac
+    except Exception:  # pragma: no cover
+        pass
+
+    return {
+        "category": "arp_spoof",
+        "score": len(suspects),
+        "details": {"suspects": list(suspects)},
+    }
+

--- a/src/scans/dns.py
+++ b/src/scans/dns.py
@@ -1,10 +1,26 @@
-"""Static scan for DNS records."""
+"""Static scan for DNS resolution using scapy."""
 
-from ..models import ScanResult
+from scapy.all import IP, UDP, DNS, DNSQR, sr1  # type: ignore
 
 
-def scan() -> ScanResult:
-    """Return dummy DNS data."""
-    severity = "low"
-    message = "No suspicious DNS records."
-    return ScanResult.from_severity(category="dns", message=message, severity=severity)
+def scan(domain: str = "example.com", server: str = "8.8.8.8") -> dict:
+    """Query *domain* using DNS and return any answers."""
+
+    answers = []
+    try:
+        pkt = IP(dst=server) / UDP(sport=12345, dport=53) / DNS(rd=1, qd=DNSQR(qname=domain))
+        resp = sr1(pkt, timeout=2, verbose=False)
+        if resp and resp.haslayer(DNS) and resp[DNS].ancount > 0:
+            for i in range(resp[DNS].ancount):
+                ans = resp[DNS].an[i]
+                if getattr(ans, "rdata", None):
+                    answers.append(str(ans.rdata))
+    except Exception:  # pragma: no cover
+        pass
+
+    return {
+        "category": "dns",
+        "score": len(answers),
+        "details": {"domain": domain, "answers": answers},
+    }
+

--- a/src/scans/os_banner.py
+++ b/src/scans/os_banner.py
@@ -1,10 +1,30 @@
-"""Static scan for OS banner detection."""
+"""Static scan for service banners using nmap."""
 
-from ..models import ScanResult
+import nmap
 
 
-def scan() -> ScanResult:
-    """Return dummy OS banner data."""
-    severity = "low"
-    message = "No OS banners captured."
-    return ScanResult.from_severity(category="os_banner", message=message, severity=severity)
+def scan(target: str = "127.0.0.1") -> dict:
+    """Attempt to grab service banners from *target*.
+
+    Returns a result dictionary containing discovered banners. The score is the
+    number of distinct banners captured.
+    """
+
+    scanner = nmap.PortScanner()
+    banners: dict[int, str] = {}
+    try:
+        result = scanner.scan(target, arguments="-sV --top-ports 10")
+        tcp_info = result.get("scan", {}).get(target, {}).get("tcp", {})
+        for port, data in tcp_info.items():
+            banner = " ".join(filter(None, [data.get("name"), data.get("version")])).strip()
+            if banner:
+                banners[int(port)] = banner
+    except Exception:  # pragma: no cover
+        pass
+
+    return {
+        "category": "os_banner",
+        "score": len(banners),
+        "details": {"target": target, "banners": banners},
+    }
+

--- a/src/scans/ports.py
+++ b/src/scans/ports.py
@@ -1,10 +1,27 @@
-"""Static scan for open ports."""
+"""Static scan for open ports using nmap."""
 
-from ..models import ScanResult
+import nmap
 
 
-def scan() -> ScanResult:
-    """Return dummy port scan data."""
-    severity = "low"
-    message = "No open ports detected."
-    return ScanResult.from_severity(category="ports", message=message, severity=severity)
+def scan(target: str = "127.0.0.1") -> dict:
+    """Scan top ports on *target* and return a unified result dict.
+
+    The scan is best-effort; if ``nmap`` is unavailable or fails, the
+    function falls back to reporting no open ports.
+    """
+
+    scanner = nmap.PortScanner()
+    open_ports = []
+    try:
+        result = scanner.scan(target, arguments="-T4 --top-ports 10")
+        tcp_info = result.get("scan", {}).get(target, {}).get("tcp", {})
+        open_ports = [int(p) for p, data in tcp_info.items() if data.get("state") == "open"]
+    except Exception:  # pragma: no cover - nmap failures are non-fatal
+        pass
+
+    return {
+        "category": "ports",
+        "score": len(open_ports),
+        "details": {"target": target, "open_ports": open_ports},
+    }
+

--- a/src/scans/smb_netbios.py
+++ b/src/scans/smb_netbios.py
@@ -1,10 +1,30 @@
-"""Static scan for SMB/NetBIOS hosts."""
+"""Static scan for SMB/NetBIOS services using nmap."""
 
-from ..models import ScanResult
+import nmap
 
 
-def scan() -> ScanResult:
-    """Return dummy SMB/NetBIOS data."""
-    severity = "low"
-    message = "No SMB/NetBIOS hosts found."
-    return ScanResult.from_severity(category="smb_netbios", message=message, severity=severity)
+def scan(target: str = "127.0.0.1") -> dict:
+    """Check for open SMB-related ports on *target*.
+
+    Ports 137-139 and 445 are inspected. The score equals the number of open
+    SMB/NetBIOS ports detected.
+    """
+
+    scanner = nmap.PortScanner()
+    open_ports = []
+    try:
+        result = scanner.scan(target, arguments="-p 137,138,139,445 -sU -sT")
+        host_info = result.get("scan", {}).get(target, {})
+        for proto in ("tcp", "udp"):
+            for port, data in host_info.get(proto, {}).items():
+                if data.get("state") == "open":
+                    open_ports.append(int(port))
+    except Exception:  # pragma: no cover
+        pass
+
+    return {
+        "category": "smb_netbios",
+        "score": len(open_ports),
+        "details": {"target": target, "open_ports": open_ports},
+    }
+

--- a/src/scans/ssl_cert.py
+++ b/src/scans/ssl_cert.py
@@ -1,10 +1,31 @@
-"""Static scan for SSL certificates."""
+"""Static scan for SSL certificate issues."""
 
-from ..models import ScanResult
+from datetime import datetime
+import socket
+import ssl
 
 
-def scan() -> ScanResult:
-    """Return dummy SSL certificate data."""
-    severity = "low"
-    message = "No SSL certificate issues found."
-    return ScanResult.from_severity(category="ssl_cert", message=message, severity=severity)
+def scan(host: str = "example.com", port: int = 443) -> dict:
+    """Retrieve the server certificate and check for expiration."""
+
+    expired = False
+    cert_data = {}
+    try:
+        context = ssl.create_default_context()
+        with socket.create_connection((host, port), timeout=2) as sock:
+            with context.wrap_socket(sock, server_hostname=host) as ssock:
+                cert = ssock.getpeercert()
+                cert_data = cert
+                not_after = cert.get("notAfter")
+                if not_after:
+                    expiry = datetime.strptime(not_after, "%b %d %H:%M:%S %Y %Z")
+                    expired = expiry < datetime.utcnow()
+    except Exception:  # pragma: no cover
+        pass
+
+    return {
+        "category": "ssl_cert",
+        "score": 1 if expired else 0,
+        "details": {"host": host, "expired": expired, "cert": cert_data},
+    }
+

--- a/src/scans/upnp.py
+++ b/src/scans/upnp.py
@@ -1,10 +1,34 @@
-"""Static scan for UPnP services."""
+"""Static scan for UPnP/SSDP services using scapy."""
 
-from ..models import ScanResult
+from scapy.all import IP, UDP, Raw, sr1  # type: ignore
 
 
-def scan() -> ScanResult:
-    """Return dummy UPnP data."""
-    severity = "low"
-    message = "No UPnP services discovered."
-    return ScanResult.from_severity(category="upnp", message=message, severity=severity)
+def scan(target: str = "239.255.255.250") -> dict:
+    """Send an SSDP M-SEARCH and record any response.
+
+    The function gracefully handles environments where raw sockets are not
+    permitted by returning an empty result.
+    """
+
+    query = (
+        "M-SEARCH * HTTP/1.1\r\n"
+        "HOST: 239.255.255.250:1900\r\n"
+        'MAN: "ssdp:discover"\r\n'
+        "MX: 1\r\n"
+        "ST: ssdp:all\r\n\r\n"
+    )
+    responders = []
+    try:
+        pkt = IP(dst=target) / UDP(sport=1900, dport=1900) / Raw(load=query)
+        ans = sr1(pkt, timeout=1, verbose=False)
+        if ans:
+            responders.append(ans.src)
+    except Exception:  # pragma: no cover
+        pass
+
+    return {
+        "category": "upnp",
+        "score": len(responders),
+        "details": {"responders": responders},
+    }
+

--- a/src/static_scan.py
+++ b/src/static_scan.py
@@ -3,7 +3,6 @@
 from concurrent.futures import ThreadPoolExecutor
 from typing import Dict
 
-from .models import ScanResult
 from .scans import (
     ports,
     os_banner,
@@ -27,11 +26,19 @@ SCANNERS = [
 ]
 
 
-def run_all() -> Dict[str, ScanResult]:
-    """Run all static scans concurrently and aggregate their results."""
+def run_all() -> Dict[str, Dict]:
+    """Run all static scans concurrently and aggregate their results.
+
+    Returns a dictionary with ``findings`` mapping categories to result dicts and
+    ``risk_score`` representing the total score across all scans.
+    """
+
     with ThreadPoolExecutor() as executor:
         futures = [executor.submit(scanner) for scanner in SCANNERS]
         results = [future.result() for future in futures]
 
-    combined: Dict[str, ScanResult] = {res.category: res for res in results}
-    return combined
+    findings: Dict[str, Dict] = {res["category"]: res for res in results}
+    total = sum(res.get("score", 0) for res in results)
+
+    return {"findings": findings, "risk_score": total}
+

--- a/tests/test_static_scan.py
+++ b/tests/test_static_scan.py
@@ -9,7 +9,6 @@ from src.scans import (
     dns,
     ssl_cert,
 )
-from src.models import ScanResult, compute_total, compute_score
 import pytest
 
 
@@ -25,13 +24,18 @@ def test_run_all_returns_all_categories():
         "dns",
         "ssl_cert",
     }
-    assert set(results.keys()) == expected
-    for category, data in results.items():
-        assert isinstance(data, ScanResult)
-        assert data.category == category
-        assert isinstance(data.score, int)
-        assert isinstance(data.message, str)
-        assert isinstance(data.severity, str)
+    assert set(results["findings"].keys()) == expected
+    assert isinstance(results["risk_score"], int)
+    for category, data in results["findings"].items():
+        assert data["category"] == category
+        assert isinstance(data["score"], int)
+        assert isinstance(data["details"], dict)
+
+
+def test_run_all_totals_scores():
+    results = static_scan.run_all()
+    total = sum(item["score"] for item in results["findings"].values())
+    assert results["risk_score"] == total
 
 
 @pytest.mark.parametrize(
@@ -47,28 +51,8 @@ def test_run_all_returns_all_categories():
         (ssl_cert, "ssl_cert"),
     ],
 )
-def test_individual_scans_return_scanresult(module, category):
+def test_individual_scans_return_dict(module, category):
     result = module.scan()
-    assert isinstance(result, ScanResult)
-    assert result.category == category
-    assert isinstance(result.score, int)
-    assert isinstance(result.severity, str)
-
-
-def test_helper_functions_compute_scores_and_total():
-    low = compute_score("low")
-    high = compute_score("high")
-    assert high > low
-    results = [
-        ScanResult("a", "", low, "low"),
-        ScanResult("b", "", high, "high"),
-    ]
-    assert compute_total(results) == low + high
-
-
-def test_scanresult_factory_computes_score():
-    result = ScanResult.from_severity("cat", "msg", "medium")
-    assert result.score == compute_score("medium")
-    assert result.category == "cat"
-    assert result.message == "msg"
-    assert result.severity == "medium"
+    assert result["category"] == category
+    assert isinstance(result["score"], int)
+    assert isinstance(result["details"], dict)


### PR DESCRIPTION
## Summary
- add nmap/scapy/ssl based scans for ports, OS banners, SMB/NetBIOS, UPnP, ARP spoofing, DHCP, DNS and SSL certificates
- aggregate scans into risk report with total score
- test unified dict structure for scan results

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892fe45b0a08323956de24a81baa6e0