### PR TITLE
feat: add concurrent static scan runner

### DIFF
--- a/src/static_scan.py
+++ b/src/static_scan.py
@@ -1,37 +1,83 @@
-"""Aggregate multiple static network scan modules."""
+"""Aggregate and run all static network scan modules."""
 
-from concurrent.futures import ThreadPoolExecutor
-from typing import Dict
+from __future__ import annotations
 
+import importlib
+import pkgutil
+from concurrent.futures import ThreadPoolExecutor, wait
+from typing import Any, Callable, Dict, Iterable, List, Tuple
+
+from . import scans
 from .models import ScanResult
-from .scans import (
-    ports,
-    os_banner,
-    smb_netbios,
-    upnp,
-    arp_spoof,
-    dhcp,
-    dns,
-    ssl_cert,
-)
 
-SCANNERS = [
-    ports.scan,
-    os_banner.scan,
-    smb_netbios.scan,
-    upnp.scan,
-    arp_spoof.scan,
-    dhcp.scan,
-    dns.scan,
-    ssl_cert.scan,
-]
+DEFAULT_TIMEOUT = 5  # seconds
 
 
-def run_all() -> Dict[str, ScanResult]:
-    """Run all static scans concurrently and aggregate their results."""
+def _discover_scanners() -> List[Tuple[str, Callable[[], ScanResult]]]:
+    """Return list of (module_name, scan_function) under :mod:`scans`."""
+    scanners: List[Tuple[str, Callable[[], ScanResult]]] = []
+    for info in pkgutil.iter_modules(scans.__path__):
+        module = importlib.import_module(f"{scans.__name__}.{info.name}")
+        scan = getattr(module, "scan", None)
+        if callable(scan):
+            scanners.append((info.name, scan))
+    return scanners
+
+
+def _result_to_dict(result: ScanResult) -> Dict[str, Any]:
+    """Convert :class:`ScanResult` to plain dictionary."""
+    return {
+        "category": result.category,
+        "message": result.message,
+        "score": result.score,
+        "severity": result.severity,
+    }
+
+
+def run_all(timeout: float = DEFAULT_TIMEOUT) -> Dict[str, Any]:
+    """Run all static scans concurrently and return aggregated results.
+
+    Parameters
+    ----------
+    timeout:
+        Time limit in seconds for all scans. Scans still running after this
+        period are marked as timed out.
+    """
+
+    scanners = _discover_scanners()
+    results: List[Dict[str, Any]] = []
+
     with ThreadPoolExecutor() as executor:
-        futures = [executor.submit(scanner) for scanner in SCANNERS]
-        results = [future.result() for future in futures]
+        future_to_category = {executor.submit(scan): name for name, scan in scanners}
+        done, not_done = wait(future_to_category, timeout=timeout)
 
-    combined: Dict[str, ScanResult] = {res.category: res for res in results}
-    return combined
+        for future in done:
+            category = future_to_category[future]
+            try:
+                res = future.result()
+                results.append(_result_to_dict(res))
+            except Exception as exc:  # pylint: disable=broad-except
+                # エラーも結果として記録
+                results.append(
+                    {
+                        "category": category,
+                        "message": str(exc),
+                        "severity": "error",
+                        "score": 0,
+                    }
+                )
+
+        for future in not_done:
+            category = future_to_category[future]
+            results.append(
+                {
+                    "category": category,
+                    "message": "timeout",
+                    "severity": "error",
+                    "score": 0,
+                }
+            )
+            future.cancel()
+
+    risk_score = sum(item["score"] for item in results)
+    return {"findings": results, "risk_score": risk_score}


### PR DESCRIPTION
## Summary
- run all static scan modules concurrently and aggregate JSON findings
- handle per-scan errors and timeouts while computing risk score
- add tests for new runner behavior

## Testing
- `pip install -r requirements.txt`
- `pytest`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689301a52aa0832389ea8bf917457c98