### PR TITLE
Add scheduler for dynamic scans and history filtering

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ uvicorn
 httpx
 reportlab
 PyPDF2
+apscheduler

--- a/src/dynamic_scan/scheduler.py
+++ b/src/dynamic_scan/scheduler.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import asyncio
+from contextlib import suppress
+from typing import Iterable, Optional
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+
+from . import capture, analyze, storage
+
+
+class DynamicScanScheduler:
+    """APScheduler を用いて定期的なダイナミックスキャンを管理するクラス"""
+
+    def __init__(self) -> None:
+        self.scheduler: AsyncIOScheduler | None = None
+        self.job = None
+        self.capture_task: asyncio.Task | None = None
+        self.analyse_task: asyncio.Task | None = None
+        self.storage: storage.Storage = storage.Storage()
+
+    async def _run_scan(self, interface: str | None, duration: int | None, approved_macs: Iterable[str] | None) -> None:
+        """実際に 1 回のスキャンを実行する内部メソッド"""
+        queue: asyncio.Queue = asyncio.Queue()
+        self.capture_task = asyncio.create_task(
+            capture.capture_packets(queue, interface=interface, duration=duration)
+        )
+        self.analyse_task = asyncio.create_task(
+            analyze.analyse_packets(queue, self.storage, approved_macs=approved_macs or [])
+        )
+        try:
+            await asyncio.gather(self.capture_task, self.analyse_task)
+        finally:
+            self.capture_task = None
+            self.analyse_task = None
+
+    def start(
+        self,
+        *,
+        interface: str | None = None,
+        duration: int | None = None,
+        approved_macs: Iterable[str] | None = None,
+        interval: int = 3600,
+    ) -> None:
+        """スケジューラを開始し、定期スキャンを設定する"""
+        # ストレージを新たに生成（テスト時は monkeypatch で差し替え可能）
+        self.storage = storage.Storage()
+        if self.scheduler is None:
+            self.scheduler = AsyncIOScheduler()
+            self.scheduler.start()
+        if self.job:
+            self.job.remove()
+        # APScheduler でコルーチンを定期実行
+        self.job = self.scheduler.add_job(
+            self._run_scan,
+            "interval",
+            seconds=interval,
+            args=[interface, duration, approved_macs],
+        )
+
+    async def stop(self) -> None:
+        """スケジュールされたジョブと進行中のタスクを停止"""
+        if self.job:
+            self.job.remove()
+            self.job = None
+        for task in (self.capture_task, self.analyse_task):
+            if task:
+                task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await task
+        self.capture_task = self.analyse_task = None
+        if self.scheduler and self.scheduler.running:
+            try:
+                self.scheduler.shutdown(wait=False)
+            except RuntimeError:
+                # イベントループが既に閉じている場合は無視
+                pass
+            self.scheduler = None

--- a/tests/test_api_dynamic_scan.py
+++ b/tests/test_api_dynamic_scan.py
@@ -2,13 +2,13 @@ import asyncio
 from fastapi.testclient import TestClient
 
 from src import api
-from src.dynamic_scan import capture, analyze, storage
+from src.dynamic_scan import capture, analyze, storage, scheduler
 
 
 def test_dynamic_scan_endpoints(monkeypatch, tmp_path):
     client = TestClient(api.app)
     store = storage.Storage(tmp_path / "res.db")
-    api.storage_obj = store
+    api.scan_scheduler = scheduler.DynamicScanScheduler()
     # start_scan 内で Storage() が呼ばれても同じインスタンスを返すようにする
     monkeypatch.setattr(storage, "Storage", lambda *args, **kwargs: store)
 
@@ -23,17 +23,17 @@ def test_dynamic_scan_endpoints(monkeypatch, tmp_path):
 
     resp = client.post("/scan/dynamic/start", json={"duration": 0})
     assert resp.status_code == 200
-    assert resp.json() == {"status": "started"}
+    assert resp.json() == {"status": "scheduled"}
 
     resp2 = client.post("/scan/dynamic/stop")
     assert resp2.status_code == 200
     assert resp2.json() == {"status": "stopped"}
 
-    asyncio.run(api.storage_obj.save_result({"key": "value"}))
+    asyncio.run(api.scan_scheduler.storage.save_result({"key": "value"}))
     resp3 = client.get("/scan/dynamic/results")
     assert resp3.status_code == 200
     assert resp3.json()["results"][0]["key"] == "value"
 
-    resp4 = client.get("/scan/dynamic/history", params={"from": "1970-01-01", "to": "2100-01-01"})
+    resp4 = client.get("/scan/dynamic/history", params={"start": "1970-01-01", "end": "2100-01-01"})
     assert resp4.status_code == 200
     assert resp4.json()["results"][0]["key"] == "value"

--- a/tests/test_dynamic_scan_storage.py
+++ b/tests/test_dynamic_scan_storage.py
@@ -10,29 +10,37 @@ def test_storage_save_and_fetch(tmp_path):
     q = asyncio.Queue()
     store.add_listener(q)
 
-    asyncio.run(store.save_result({"foo": "bar"}))
+    asyncio.run(store.save_result({"foo": "bar", "src_ip": "1.1.1.1", "protocol": "http"}))
     first = store.get_all()[0]
     assert first["foo"] == "bar"
     assert q.get_nowait()["foo"] == "bar"
 
     store.remove_listener(q)
-    asyncio.run(store.save_result({"baz": "qux"}))
+    asyncio.run(store.save_result({"baz": "qux", "src_ip": "2.2.2.2", "protocol": "ftp"}))
     assert len(store.get_all()) == 2
     assert q.empty()
 
-    today = datetime.utcnow().date()
-    start = (today - timedelta(days=1)).isoformat()
-    end = (today + timedelta(days=1)).isoformat()
-    history = store.fetch_results(start, end)
+    now = datetime.utcnow()
+    start = (now - timedelta(days=1)).isoformat()
+    end = (now + timedelta(days=1)).isoformat()
+    history = store.fetch_history({"start": start, "end": end})
     assert len(history) == 2
+
+    ftp_only = store.fetch_history({"start": start, "end": end, "protocol": "ftp"})
+    assert len(ftp_only) == 1
+    assert ftp_only[0]["protocol"] == "ftp"
+
+    device_only = store.fetch_history({"start": start, "end": end, "device": "2.2.2.2"})
+    assert len(device_only) == 1
+    assert device_only[0]["src_ip"] == "2.2.2.2"
 
 
 def test_storage_fetch_out_of_range(tmp_path):
     store = Storage(tmp_path / "res.db")
     # 保存された結果の日付より後ろの期間を指定
     asyncio.run(store.save_result({"foo": "bar"}))
-    today = datetime.utcnow().date()
-    start = (today + timedelta(days=1)).isoformat()
-    end = (today + timedelta(days=2)).isoformat()
-    history = store.fetch_results(start, end)
+    now = datetime.utcnow()
+    start = (now + timedelta(days=1)).isoformat()
+    end = (now + timedelta(days=2)).isoformat()
+    history = store.fetch_history({"start": start, "end": end})
     assert history == []


### PR DESCRIPTION
## Summary
- manage dynamic scans with APScheduler scheduler
- support querying stored results with flexible filters
- expose `/scan/dynamic/history` for retrieving filtered scan history

## Testing
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689301bce1708323b1172f5f82087313