### PR TITLE
Fix static scan progress indicator not shown

### DIFF
--- a/nw_checker/lib/static_scan_tab.dart
+++ b/nw_checker/lib/static_scan_tab.dart
@@ -24,18 +24,21 @@ class _StaticScanTabState extends State<StaticScanTab> {
   bool _showOutput = false;
   List<String> _outputLines = [];
 
-  void _startScan() {
+  void _startScan() async {
     setState(() {
       _isLoading = true;
       _showOutput = false;
     });
-    widget.scanner().then((lines) {
-      if (!mounted) return;
-      setState(() {
-        _isLoading = false;
-        _showOutput = true;
-        _outputLines = lines;
-      });
+
+    // Allow UI to display progress indicator before starting the scan.
+    await Future<void>.delayed(Duration.zero);
+
+    final lines = await widget.scanner();
+    if (!mounted) return;
+    setState(() {
+      _isLoading = false;
+      _showOutput = true;
+      _outputLines = lines;
     });
   }
 


### PR DESCRIPTION
## Summary
- ensure StaticScanTab shows loading state for at least one frame before displaying scan results

## Testing
- `pip install -r requirements.txt`
- `pytest`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_689300342c548323bc937a5954b6be4c