### PR TITLE
feat: run static scans concurrently

### DIFF
--- a/src/static_scan.py
+++ b/src/static_scan.py
@@ -1,44 +1,63 @@
-"""Aggregate multiple static network scan modules."""
+"""Run all static scan modules concurrently with fault tolerance."""
 
-from concurrent.futures import ThreadPoolExecutor
-from typing import Dict
+from concurrent.futures import ThreadPoolExecutor, TimeoutError
+from importlib import import_module
+from pkgutil import iter_modules
+from typing import Dict, List, Tuple
 
-from .scans import (
-    ports,
-    os_banner,
-    smb_netbios,
-    upnp,
-    arp_spoof,
-    dhcp,
-    dns,
-    ssl_cert,
-)
-
-SCANNERS = [
-    ports.scan,
-    os_banner.scan,
-    smb_netbios.scan,
-    upnp.scan,
-    arp_spoof.scan,
-    dhcp.scan,
-    dns.scan,
-    ssl_cert.scan,
-]
+from . import scans
 
 
-def run_all() -> Dict[str, Dict]:
-    """Run all static scans concurrently and aggregate their results.
+def _load_scanners() -> List[Tuple[str, callable]]:
+    """Discover scan functions under :mod:`src.scans`.
 
-    Returns a dictionary with ``findings`` mapping categories to result dicts and
-    ``risk_score`` representing the total score across all scans.
+    Returns a list of ``(module_name, scan_callable)`` tuples.
     """
 
+    scanners: List[Tuple[str, callable]] = []
+    for mod_info in iter_modules(scans.__path__):
+        if mod_info.name.startswith("_"):
+            continue
+        module = import_module(f"{scans.__name__}.{mod_info.name}")
+        scan_func = getattr(module, "scan", None)
+        if callable(scan_func):
+            scanners.append((mod_info.name, scan_func))
+    return scanners
+
+
+def run_all(timeout: float = 5.0) -> Dict[str, List[Dict]]:
+    """Execute all static scans and aggregate their results.
+
+    Each scan runs in a thread. Failures or timeouts still produce a result
+    entry with ``score`` 0 and an ``error`` message in ``details``.
+    """
+
+    findings: List[Dict] = []
+    scanners = _load_scanners()
+
     with ThreadPoolExecutor() as executor:
-        futures = [executor.submit(scanner) for scanner in SCANNERS]
-        results = [future.result() for future in futures]
+        future_map = {executor.submit(scan): name for name, scan in scanners}
+        for future, name in future_map.items():
+            try:
+                result = future.result(timeout=timeout)
+                # フィールド欠損時のフォールバック
+                result.setdefault("category", name)
+                result.setdefault("score", 0)
+                result.setdefault("details", {})
+            except TimeoutError:
+                result = {
+                    "category": name,
+                    "score": 0,
+                    "details": {"error": "timeout"},
+                }
+            except Exception as exc:  # noqa: BLE001 - エラーも結果に含める
+                result = {
+                    "category": name,
+                    "score": 0,
+                    "details": {"error": str(exc)},
+                }
+            findings.append(result)
 
-    findings: Dict[str, Dict] = {res["category"]: res for res in results}
-    total = sum(res.get("score", 0) for res in results)
-
+    total = sum(item.get("score", 0) for item in findings)
     return {"findings": findings, "risk_score": total}
 

--- a/tests/test_static_scan.py
+++ b/tests/test_static_scan.py
@@ -10,6 +10,12 @@ from src.scans import (
     ssl_cert,
 )
 import pytest
+import time
+import json
+
+
+def _findings_by_category(results):
+    return {item["category"]: item for item in results["findings"]}
 
 
 def test_run_all_returns_all_categories():
@@ -24,28 +30,61 @@ def test_run_all_returns_all_categories():
         "dns",
         "ssl_cert",
     }
-    assert set(results["findings"].keys()) == expected
+    categories = {item["category"] for item in results["findings"]}
+    assert categories == expected
     assert isinstance(results["risk_score"], int)
-    for category, data in results["findings"].items():
-        assert data["category"] == category
-        assert isinstance(data["score"], int)
-        assert isinstance(data["details"], dict)
+    for item in results["findings"]:
+        assert isinstance(item["score"], int)
+        assert isinstance(item["details"], dict)
 
 
 def test_run_all_totals_scores():
     results = static_scan.run_all()
-    total = sum(item["score"] for item in results["findings"].values())
+    total = sum(item["score"] for item in results["findings"])
     assert results["risk_score"] == total
 
 
-def test_run_all_propagates_scanner_exception(monkeypatch):
+def test_run_all_handles_exceptions_and_timeouts(monkeypatch):
     def boom():
         raise RuntimeError("boom")
 
-    monkeypatch.setattr(static_scan, "SCANNERS", [boom])
+    def slow():
+        time.sleep(2)
 
-    with pytest.raises(RuntimeError):
-        static_scan.run_all()
+    monkeypatch.setattr(dns, "scan", boom)
+    monkeypatch.setattr(os_banner, "scan", slow)
+
+    results = static_scan.run_all(timeout=0.5)
+    by_cat = _findings_by_category(results)
+
+    assert by_cat["dns"]["details"]["error"] == "boom"
+    assert by_cat["dns"]["score"] == 0
+    assert by_cat["os_banner"]["details"]["error"] == "timeout"
+    assert by_cat["os_banner"]["score"] == 0
+
+
+def test_run_all_populates_missing_fields(monkeypatch):
+    """スキャン結果の欠損フィールドを補完することを確認"""
+
+    def incomplete():
+        return {}
+
+    monkeypatch.setattr(dhcp, "scan", incomplete)
+
+    results = static_scan.run_all()
+    by_cat = _findings_by_category(results)
+    entry = by_cat["dhcp"]
+
+    assert entry["category"] == "dhcp"
+    assert entry["score"] == 0
+    assert entry["details"] == {}
+
+
+def test_run_all_is_json_serializable():
+    """run_all の返り値が JSON シリアル化可能であることを確認"""
+
+    results = static_scan.run_all()
+    json.dumps(results)  # 例外が発生しなければOK
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- run all `src.scans` modules concurrently and collect findings
- handle timeouts and exceptions so every scan yields a result entry
- compute a total risk score and return JSON-serializable data
- add tests for missing field fallback and JSON serialization

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68930938f35483239c9cf79613c0d69f