### PR TITLE
Fix static scan progress indicator not shown

### DIFF
--- a/nw_checker/lib/static_scan_tab.dart
+++ b/nw_checker/lib/static_scan_tab.dart
@@ -29,7 +29,13 @@ class _StaticScanTabState extends State<StaticScanTab> {
       _isLoading = true;
       _showOutput = false;
     });
-    widget.scanner().then((lines) {
+
+    // Allow the progress indicator to render for at least one frame before
+    // kicking off the (potentially long) scan. Schedule the scan on the event
+    // queue without adding any frame time so tests can advance virtual time
+    // exactly to the scan duration without accounting for an extra delay.
+    Future<void>(() async {
+      final lines = await widget.scanner();
       if (!mounted) return;
       setState(() {
         _isLoading = false;


### PR DESCRIPTION
## Summary
- ensure StaticScanTab starts scanning on the next event loop so a loading spinner renders for a frame without affecting scan timing

## Testing
- `pip install -r requirements.txt`
- `pytest`
- `(cd nw_checker && bash ../flutter_env.sh)`
- `cd nw_checker && flutter test`


------
https://chatgpt.com/codex/tasks/task_e_689300342c548323bc937a5954b6be4c