### PR TITLE
Fix dynamic scan test parsing error

### DIFF
--- a/tests/test_api_dynamic_scan.py
+++ b/tests/test_api_dynamic_scan.py
@@ -40,7 +40,6 @@ def test_dynamic_scan_endpoints(monkeypatch, tmp_path):
             {"key": "other", "src_ip": "2.2.2.2", "protocol": "ftp"}
         )
     )
-=======
     resp3 = client.get("/scan/dynamic/results")
     assert resp3.status_code == 200
     assert len(resp3.json()["results"]) == 2


### PR DESCRIPTION
## Summary
- remove leftover conflict marker from dynamic scan API test

## Testing
- `pytest tests/test_api_dynamic_scan.py`

------
https://chatgpt.com/codex/tasks/task_e_689400b05f688323a184945772624a4f