### PR TITLE
Expose static scan endpoint and document API

### DIFF
--- a/docs/static_scan_api.md
+++ b/docs/static_scan_api.md
@@ -1,0 +1,48 @@
+# Static Scan API
+
+This endpoint triggers all static scan modules in the Python backend and aggregates their results.
+It is designed for consumption by the Flutter client.
+
+## Request
+
+- **Method**: `GET`
+- **Path**: `/static_scan`
+- **Query Parameters**:
+  - `report` *(optional, boolean)*: when `true`, a PDF report is generated and the response contains `report_path`.
+
+## Successful Response
+
+```json
+{
+  "status": "ok",
+  "findings": { /* results from static_scan.run_all() */ },
+  "risk_score": 42,
+  "report_path": "/tmp/static_scan_report.pdf" // only when report=true
+}
+```
+
+- `findings`: Aggregated findings from all scanners.
+- `risk_score`: Sum of the individual scores.
+- `report_path`: Path to the generated PDF report. Returned only when `report=true`.
+
+## Error Responses
+
+### Timeout
+- **Status Code**: `504`
+```json
+{
+  "status": "timeout",
+  "message": "Static scan timed out"
+}
+```
+
+### General Failure
+- **Status Code**: `500`
+```json
+{
+  "status": "error",
+  "message": "Static scan failed: <details>"
+}
+```
+
+The Flutter client should handle these states to provide appropriate user feedback.

--- a/src/server.py
+++ b/src/server.py
@@ -1,37 +1,52 @@
 from __future__ import annotations
 
+"""HTTP server exposing the static scan API."""
+
 import asyncio
+
 from fastapi import FastAPI
 from fastapi.responses import JSONResponse
+
 import static_scan
 from .report.pdf import create_pdf
 
 STATIC_SCAN_TIMEOUT = 60  # seconds
+REPORT_PATH = "/tmp/static_scan_report.pdf"
 
 app = FastAPI()
 
 
-@app.get('/static_scan')
+@app.get("/static_scan")
 async def static_scan_endpoint(report: bool = False):
+    """Run all static scan modules and return aggregated results.
+
+    Parameters
+    ----------
+    report: bool, optional
+        When ``True`` the server generates a PDF report and returns its path.
+    """
+
     try:
-        result = await asyncio.wait_for(asyncio.to_thread(static_scan.run_all), timeout=STATIC_SCAN_TIMEOUT)
+        result = await asyncio.wait_for(
+            asyncio.to_thread(static_scan.run_all),
+            timeout=STATIC_SCAN_TIMEOUT,
+        )
     except asyncio.TimeoutError:
-        return JSONResponse(status_code=504, content={
-            'status': 'timeout',
-            'message': 'Static scan timed out'
-        })
+        return JSONResponse(
+            status_code=504,
+            content={"status": "timeout", "message": "Static scan timed out"},
+        )
     except Exception as exc:  # pylint: disable=broad-except
-        return JSONResponse(status_code=500, content={
-            'status': 'error',
-            'message': f'Static scan failed: {exc}'
-        })
+        return JSONResponse(
+            status_code=500,
+            content={"status": "error", "message": f"Static scan failed: {exc}"},
+        )
 
-    findings = result.get('findings', {}) if isinstance(result, dict) else result
-    risk_score = result.get('risk_score') if isinstance(result, dict) else None
+    findings = result.get("findings", {}) if isinstance(result, dict) else result
+    risk_score = result.get("risk_score") if isinstance(result, dict) else None
 
-    response = {'status': 'ok', 'findings': findings, 'risk_score': risk_score}
+    response = {"status": "ok", "findings": findings, "risk_score": risk_score}
     if report:
-        output_path = '/tmp/static_scan_report.pdf'
-        create_pdf(result, output_path)
-        response['report_path'] = output_path
+        create_pdf(result, REPORT_PATH)
+        response["report_path"] = REPORT_PATH
     return response

--- a/tests/test_api_dynamic_scan.py
+++ b/tests/test_api_dynamic_scan.py
@@ -40,7 +40,6 @@ def test_dynamic_scan_endpoints(monkeypatch, tmp_path):
             {"key": "other", "src_ip": "2.2.2.2", "protocol": "ftp"}
         )
     )
-=======
     resp3 = client.get("/scan/dynamic/results")
     assert resp3.status_code == 200
     assert len(resp3.json()["results"]) == 2


### PR DESCRIPTION
## Summary
- add FastAPI endpoint `/static_scan` wrapping `static_scan.run_all`
- document request and response schema for Flutter clients
- fix dynamic scan API test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68930dd748148323ac05c0f79bb61028