### PR TITLE
feat: unify dynamic scan results format

### DIFF
--- a/nw_checker/lib/services/dynamic_scan_api.dart
+++ b/nw_checker/lib/services/dynamic_scan_api.dart
@@ -50,34 +50,31 @@ class DynamicScanApi {
         headers: _headers(),
       );
       if (resp.statusCode == 200) {
-        yield ScanReport.fromJson(jsonDecode(resp.body));
+        final decoded = jsonDecode(resp.body) as Map<String, dynamic>;
+        yield ScanReport.fromJson({
+          'riskScore': decoded['risk_score'] ?? 0,
+          'categories': decoded['categories'] ?? [],
+        });
         return;
       }
     } catch (_) {}
 
     const dummyJson = {
-      'riskScore': 87,
+      'risk_score': 1,
       'categories': [
         {
-          'name': 'Ports',
+          'name': 'protocols',
           'severity': 'high',
-          'issues': ['22/tcp open', '23/tcp open'],
-        },
-        {
-          'name': 'SMB',
-          'severity': 'medium',
-          'issues': ['SMBv1 enabled'],
-        },
-        {
-          'name': 'DNS',
-          'severity': 'low',
-          'issues': ['Zone transfer allowed'],
-        },
+          'issues': ['ftp'],
+        }
       ],
     };
     yield await Future.delayed(
       const Duration(seconds: 1),
-      () => ScanReport.fromJson(dummyJson),
+      () => ScanReport.fromJson({
+        'riskScore': dummyJson['risk_score'] as int,
+        'categories': dummyJson['categories'],
+      }),
     );
   }
 

--- a/nw_checker/test/dynamic_scan_api_test.dart
+++ b/nw_checker/test/dynamic_scan_api_test.dart
@@ -15,9 +15,9 @@ void main() {
     final reports = await DynamicScanApi.fetchResults().toList();
     expect(reports, hasLength(1));
     final report = reports.first;
-    expect(report.riskScore, 87);
-    expect(report.categories.first.name, 'Ports');
-    expect(report.categories.first.issues, contains('22/tcp open'));
+    expect(report.riskScore, 1);
+    expect(report.categories.first.name, 'protocols');
+    expect(report.categories.first.issues, contains('ftp'));
   });
 
   test('subscribeAlerts emits alerts', () async {

--- a/nw_checker/test/dynamic_scan_tab_flow_test.dart
+++ b/nw_checker/test/dynamic_scan_tab_flow_test.dart
@@ -15,7 +15,7 @@ void main() {
     expect(find.byType(CircularProgressIndicator), findsOneWidget);
 
     await tester.pump(const Duration(seconds: 1));
-    expect(find.text('Risk Score: 87'), findsOneWidget);
-    expect(find.text('Ports'), findsOneWidget);
+    expect(find.text('Risk Score: 1'), findsOneWidget);
+    expect(find.text('protocols'), findsOneWidget);
   });
 }

--- a/nw_checker/test/dynamic_scan_tab_test.dart
+++ b/nw_checker/test/dynamic_scan_tab_test.dart
@@ -23,15 +23,15 @@ void main() {
     expect(find.byType(CircularProgressIndicator), findsOneWidget);
 
     await tester.pump(const Duration(seconds: 1));
-    expect(find.text('Risk Score: 87'), findsOneWidget);
-    expect(find.text('Ports'), findsOneWidget);
+    expect(find.text('Risk Score: 1'), findsOneWidget);
+    expect(find.text('protocols'), findsOneWidget);
 
     await tester.tap(find.text('スキャン停止'));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 300));
     await tester.pump();
     expect(find.byType(CircularProgressIndicator), findsNothing);
-    expect(find.text('Risk Score: 87'), findsOneWidget);
+    expect(find.text('Risk Score: 1'), findsOneWidget);
   });
 
   testWidgets('summary shows export button and snackbar', (tester) async {
@@ -62,14 +62,14 @@ void main() {
     await tester.pump(const Duration(seconds: 1));
     await tester.pump();
 
-    final iconFinder = find.byIcon(Icons.router);
+    final iconFinder = find.byIcon(Icons.security);
     expect(iconFinder, findsOneWidget);
     final icon = tester.widget<Icon>(iconFinder);
     expect(icon.color, Colors.red);
 
-    await tester.tap(find.text('Ports'));
+    await tester.tap(find.text('protocols'));
     await tester.pump(const Duration(milliseconds: 300));
-    expect(find.text('22/tcp open'), findsOneWidget);
+    expect(find.text('ftp'), findsOneWidget);
   });
 
   testWidgets('shows snackbar on alert and navigates to detail', (tester) async {

--- a/tests/integration/test_dynamic_scan_flow.py
+++ b/tests/integration/test_dynamic_scan_flow.py
@@ -57,5 +57,7 @@ def test_dynamic_scan_full_flow(monkeypatch, tmp_path, benchmark):
     client = TestClient(api.app)
     resp = client.get("/scan/dynamic/results", headers={"Authorization": "Bearer testtoken"})
     assert resp.status_code == 200
-    assert len(resp.json()["results"]) == 5
+    body = resp.json()
+    assert body["risk_score"] == 5
+    assert body["categories"][0]["issues"] == ["telnet"]
     api.API_TOKEN = prev_token

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -29,9 +29,15 @@ def test_dynamic_scan_start_stop(monkeypatch, tmp_path):
     assert resp2.status_code == 200
     assert resp2.json()["status"] == "stopped"
 
-    asyncio.run(api.scan_scheduler.storage.save_result({"key": "value"}))
+    asyncio.run(
+        api.scan_scheduler.storage.save_result(
+            {"protocol": "ftp", "src_ip": "1.1.1.1"}
+        )
+    )
     resp3 = client.get("/scan/dynamic/results")
-    assert resp3.json()["results"][0]["key"] == "value"
+    body = resp3.json()
+    assert body["risk_score"] == 1
+    assert body["categories"][0]["issues"] == ["ftp"]
 
 
 def test_dynamic_scan_websocket_broadcast(tmp_path):

--- a/tests/test_api_dynamic_scan.py
+++ b/tests/test_api_dynamic_scan.py
@@ -40,10 +40,12 @@ def test_dynamic_scan_endpoints(monkeypatch, tmp_path):
             {"key": "other", "src_ip": "2.2.2.2", "protocol": "ftp"}
         )
     )
-=======
+
     resp3 = client.get("/scan/dynamic/results")
     assert resp3.status_code == 200
-    assert len(resp3.json()["results"]) == 2
+    body = resp3.json()
+    assert body["risk_score"] == 1
+    assert body["categories"][0]["issues"] == ["ftp"]
 
     resp4 = client.get(
         "/scan/dynamic/history",


### PR DESCRIPTION
## Summary
- provide aggregated risk score and protocol categories for `/scan/dynamic/results`
- decode new results schema on Flutter client with matching dummy data
- align Python and Dart tests with unified response structure

## Testing
- `pytest`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_6894016485cc8323bf9cd176b69da0a3