### PR TITLE
Fix setup script dependency path

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -25,10 +25,11 @@ source .venv/bin/activate
 echo "=== Python依存関係インストール ==="
 pip install --upgrade pip
 pip install python-nmap pytest
-if [ -f requirements.txt ]; then
-    pip install -r requirements.txt
+REQ_FILE="../requirements.txt"
+if [ -f "$REQ_FILE" ]; then
+    pip install -r "$REQ_FILE"
 else
-    echo "requirements.txt が見つかりません。スキップします。"
+    echo "ルートの requirements.txt が見つかりません。スキップします。"
 fi
 
 # ===== Flutter SDK セットアップ =====


### PR DESCRIPTION
## Summary
- ensure setup.sh installs dependencies from repository root requirements

## Testing
- `bash setup.sh` (failures: Python tests failed, Flutter tests passed)
- `pytest tests/test_scan_modules.py -vv` (fails: test_ssl_cert_scan_flags_expired)


------
https://chatgpt.com/codex/tasks/task_e_68953b45a3048323b0753c3960c90e86