### PR TITLE
fix: update flutter path

### DIFF
--- a/flutter_env.sh
+++ b/flutter_env.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Flutter SDKパス設定（Codex環境用）
-export PATH="$PATH:/usr/local/flutter/bin"
+export PATH="$PATH:$HOME/flutter/bin"
 
 # Flutter依存解決
 flutter pub get


### PR DESCRIPTION
## Summary
- point flutter_env.sh to `$HOME/flutter/bin`

## Testing
- `bash -lc "cd nw_checker && source ../flutter_env.sh && flutter --version"`
- `bash -lc "source nw_checker/.venv/bin/activate && pytest"` *(fails: test_ssl_cert_scan_flags_expired)*
- `bash -lc "cd nw_checker && source ../flutter_env.sh && flutter test"`


------
https://chatgpt.com/codex/tasks/task_e_68953b9ffac88323ae8cdffc0c13a5a5