### PR TITLE
Replace PyPDF2 with pypdf

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,6 @@ fastapi
 uvicorn
 httpx
 reportlab
-PyPDF2
+pypdf
 apscheduler
 pytest-benchmark

--- a/tests/test_report_pdf.py
+++ b/tests/test_report_pdf.py
@@ -1,4 +1,4 @@
-from PyPDF2 import PdfReader
+from pypdf import PdfReader
 from src.report.pdf import create_pdf
 
 


### PR DESCRIPTION
## Summary
- switch PDF dependency from PyPDF2 to pypdf
- update report PDF tests to import from pypdf

## Testing
- `pytest tests/test_report_pdf.py`


------
https://chatgpt.com/codex/tasks/task_e_68953e63dbe883239a0c8b72bf469f1a