### PR TITLE
Fix timezone comparison in SSL cert scan

### DIFF
--- a/src/scans/ssl_cert.py
+++ b/src/scans/ssl_cert.py
@@ -1,6 +1,6 @@
 """Static scan for SSL certificate issues."""
 
-from datetime import datetime
+from datetime import datetime, timezone
 import socket
 import ssl
 
@@ -18,8 +18,9 @@ def scan(host: str = "example.com", port: int = 443) -> dict:
                 cert_data = cert
                 not_after = cert.get("notAfter")
                 if not_after:
-                    expiry = datetime.strptime(not_after, "%b %d %H:%M:%S %Y %Z")
-                    from datetime import datetime, timezone
+                    expiry = datetime.strptime(not_after, "%b %d %H:%M:%S %Y %Z").replace(
+                        tzinfo=timezone.utc
+                    )
                     expired = expiry < datetime.now(timezone.utc)
     except Exception:  # pragma: no cover
         pass


### PR DESCRIPTION
## Summary
- ensure SSL certificate expiry comparison uses timezone-aware datetimes

## Testing
- `pytest tests/test_scan_modules.py::test_ssl_cert_scan_flags_expired -q`


------
https://chatgpt.com/codex/tasks/task_e_68953e59ee0483238fa80cffd559d828