### PR TITLE
chore: remove unused import

### DIFF
--- a/nw_checker/test/dynamic_scan_api_test.dart
+++ b/nw_checker/test/dynamic_scan_api_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:nw_checker/models/scan_report.dart';
 import 'package:nw_checker/services/dynamic_scan_api.dart';
 
 void main() {


### PR DESCRIPTION
## Summary
- remove unused ScanReport import from dynamic scan API test

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6895410c3a388323b57290ced5b1e359