### PR TITLE
test: verify capture stops

### DIFF
--- a/tests/test_dynamic_scan_capture.py
+++ b/tests/test_dynamic_scan_capture.py
@@ -22,3 +22,33 @@ def test_capture_packets_enqueue(monkeypatch):
     # duration=0 とすることで即終了させる
     asyncio.run(capture.capture_packets(queue, duration=0))
     assert queue.get_nowait() == "pkt"
+
+
+def test_capture_packets_stops_after_duration(monkeypatch):
+    class FakeSniffer:
+        def __init__(self, iface=None, prn=None):
+            self.started = False
+            self.stopped = False
+            FakeSniffer.instance = self
+
+        def start(self):
+            self.started = True
+
+        def stop(self):  # pragma: no cover - nothing to do in test
+            self.stopped = True
+
+    async def fake_sleep(seconds: int):
+        fake_sleep.called = seconds
+
+    fake_sleep.called = None
+
+    # モックを適用し、sleep を即時完了させる
+    monkeypatch.setattr(capture, "AsyncSniffer", FakeSniffer)
+    monkeypatch.setattr(capture.asyncio, "sleep", fake_sleep)
+
+    queue: asyncio.Queue = asyncio.Queue()
+    asyncio.run(capture.capture_packets(queue, duration=1))
+
+    assert FakeSniffer.instance.started is True
+    assert FakeSniffer.instance.stopped is True
+    assert fake_sleep.called == 1


### PR DESCRIPTION
## Summary
- add unit test ensuring AsyncSniffer stops after capture duration

## Testing
- `pytest tests/test_dynamic_scan_capture.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_689595045c088323820c589b1158cbdd