### PR TITLE
feat: add OS banner scanning

### DIFF
--- a/nw_checker/lib/static_scan_tab.dart
+++ b/nw_checker/lib/static_scan_tab.dart
@@ -44,6 +44,7 @@ class _StaticScanTabState extends State<StaticScanTab> {
     super.initState();
     _categories = [
       CategoryTile(title: 'Port Scan', icon: Icons.router),
+      CategoryTile(title: 'OS/Service', icon: Icons.computer),
       CategoryTile(title: 'SSL証明書', icon: Icons.security),
     ];
   }
@@ -69,6 +70,9 @@ class _StaticScanTabState extends State<StaticScanTab> {
           ..status = ScanStatus.ok
           ..details = ['ポート 22: open', 'ポート 80: open'];
         _categories[1]
+          ..status = ScanStatus.ok
+          ..details = ['OS: Linux', 'サービス: sshd 8.2'];
+        _categories[2]
           ..status = ScanStatus.warning
           ..details = ['証明書の期限が30日以内です'];
       });

--- a/nw_checker/test/static_scan_tab_flow_test.dart
+++ b/nw_checker/test/static_scan_tab_flow_test.dart
@@ -20,7 +20,7 @@ void main() {
     expect(find.text('スキャン未実施'), findsOneWidget);
     expect(find.byType(ListView), findsOneWidget);
     final initialChips = tester.widgetList<Chip>(find.byType(Chip)).toList();
-    expect(initialChips, hasLength(2));
+    expect(initialChips, hasLength(3));
     expect(initialChips.every((c) => c.backgroundColor == Colors.grey), isTrue);
 
     await tester.tap(find.byKey(const Key('staticButton')));
@@ -35,17 +35,25 @@ void main() {
 
     // Category order
     final portDy = tester.getTopLeft(find.text('Port Scan')).dy;
+    final osDy = tester.getTopLeft(find.text('OS/Service')).dy;
     final sslDy = tester.getTopLeft(find.text('SSL証明書')).dy;
-    expect(portDy < sslDy, isTrue);
+    expect(portDy < osDy && osDy < sslDy, isTrue);
 
     // Status badges and colors after scan
     final chipsAfter = tester.widgetList<Chip>(find.byType(Chip)).toList();
     final firstLabel = chipsAfter[0].label as Text;
     final secondLabel = chipsAfter[1].label as Text;
+    final thirdLabel = chipsAfter[2].label as Text;
     expect(firstLabel.data, 'OK');
     expect(chipsAfter[0].backgroundColor, Colors.blueGrey);
-    expect(secondLabel.data, '警告');
-    expect(chipsAfter[1].backgroundColor, Colors.orange);
+    expect(secondLabel.data, 'OK');
+    expect(chipsAfter[1].backgroundColor, Colors.blueGrey);
+    expect(thirdLabel.data, '警告');
+    expect(chipsAfter[2].backgroundColor, Colors.orange);
+
+    await tester.tap(find.text('OS/Service'));
+    await tester.pumpAndSettle();
+    expect(find.text('OS: Linux'), findsOneWidget);
 
     await tester.tap(find.text('SSL証明書'));
     await tester.pumpAndSettle();

--- a/nw_checker/test/widgets_component_test.dart
+++ b/nw_checker/test/widgets_component_test.dart
@@ -54,6 +54,4 @@ group('AlertComponent', () {
     expect(find.text('warning'), findsOneWidget);
   });
 });
-
-  });
 }

--- a/src/scans/os_banner.py
+++ b/src/scans/os_banner.py
@@ -1,30 +1,42 @@
-"""Static scan for service banners using nmap."""
+"""Static scan for OS and service banners using nmap."""
 
 import nmap
 
 
 def scan(target: str = "127.0.0.1") -> dict:
-    """Attempt to grab service banners from *target*.
+    """Attempt to grab service banners and detect OS from *target*.
 
-    Returns a result dictionary containing discovered banners. The score is the
-    number of distinct banners captured.
+    Returns a result dictionary containing discovered banners and the detected
+    OS name (if any). The score is the number of distinct banners plus one when
+    the OS is identified.
     """
 
     scanner = nmap.PortScanner()
     banners: dict[int, str] = {}
+    os_name = ""
     try:
-        result = scanner.scan(target, arguments="-sV --top-ports 10")
-        tcp_info = result.get("scan", {}).get(target, {}).get("tcp", {})
+        # OS判別(-O)とサービスバナー取得(-sV)
+        result = scanner.scan(target, arguments="-O -sV --top-ports 10")
+        host_info = result.get("scan", {}).get(target, {})
+
+        tcp_info = host_info.get("tcp", {})
         for port, data in tcp_info.items():
-            banner = " ".join(filter(None, [data.get("name"), data.get("version")])).strip()
+            banner = " ".join(
+                filter(None, [data.get("name"), data.get("version")])
+            ).strip()
             if banner:
                 banners[int(port)] = banner
+
+        matches = host_info.get("osmatch", [])
+        if matches:
+            os_name = matches[0].get("name", "")
     except Exception:  # pragma: no cover
         pass
 
+    score = len(banners) + (1 if os_name else 0)
     return {
         "category": "os_banner",
-        "score": len(banners),
-        "details": {"target": target, "banners": banners},
+        "score": score,
+        "details": {"target": target, "banners": banners, "os": os_name},
     }
 

--- a/tests/test_os_banner.py
+++ b/tests/test_os_banner.py
@@ -1,0 +1,26 @@
+from src.scans import os_banner
+
+
+class FakeScanner:
+    def scan(self, target, arguments):
+        assert "-O" in arguments and "-sV" in arguments
+        return {
+            "scan": {
+                target: {
+                    "osmatch": [{"name": "Linux 5.x"}],
+                    "tcp": {22: {"name": "ssh", "version": "OpenSSH 8.2"}},
+                }
+            }
+        }
+
+
+def fake_portscanner():
+    return FakeScanner()
+
+
+def test_os_banner_collects_os_and_services(monkeypatch):
+    monkeypatch.setattr(os_banner.nmap, "PortScanner", fake_portscanner)
+    result = os_banner.scan("1.2.3.4")
+    assert result["details"]["banners"] == {22: "ssh OpenSSH 8.2"}
+    assert result["details"]["os"] == "Linux 5.x"
+    assert result["score"] == 2

--- a/tests/test_static_scan.py
+++ b/tests/test_static_scan.py
@@ -38,6 +38,14 @@ def test_run_all_returns_all_categories():
         assert isinstance(item["details"], dict)
 
 
+def test_run_all_orders_port_then_os_banner():
+    """ポートスキャンの次にOSバナーが実行されることを確認"""
+
+    results = static_scan.run_all()
+    categories = [item["category"] for item in results["findings"]]
+    assert categories[:2] == ["ports", "os_banner"]
+
+
 def test_run_all_totals_scores():
     results = static_scan.run_all()
     total = sum(item["score"] for item in results["findings"])


### PR DESCRIPTION
## Summary
- enhance os_banner scan to detect OS via `nmap -O -sV`
- ensure `os_banner` runs after port scan in static scan pipeline
- surface OS/service details in static scan Flutter UI

## Testing
- `pytest tests/test_os_banner.py tests/test_static_scan.py`
- `cd nw_checker && flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6895e1864d4c8323b18065dcb9fdafe7