### PR TITLE
Add GeoIP lookup utility

### DIFF
--- a/tests/test_dynamic_scan_analyze.py
+++ b/tests/test_dynamic_scan_analyze.py
@@ -61,6 +61,20 @@ def test_assign_geoip_info(monkeypatch):
     assert res.geoip == {"country": "Wonderland", "ip": "203.0.113.1"}
 
 
+def test_attach_geoip(monkeypatch):
+    class FakeResp:
+        ok = True
+
+        def json(self):  # pragma: no cover - 単純な dict 返却
+            return {"country_name": "Wonderland"}
+
+    monkeypatch.setattr(analyze.requests, "get", lambda url, timeout=5: FakeResp())
+    res = analyze.AnalysisResult()
+    updated = analyze.attach_geoip(res, "203.0.113.1")
+    assert updated.geoip == {"country": "Wonderland", "ip": "203.0.113.1"}
+    assert updated.src_ip == "203.0.113.1"
+
+
 def test_record_dns_history(monkeypatch):
     analyze._dns_history.clear()
     monkeypatch.setattr(analyze, "reverse_dns_lookup", lambda ip: "host.example")


### PR DESCRIPTION
## Summary
- Enhance geoip lookup with optional GeoIP2 database and external API fallback
- Add `attach_geoip` utility to store geoip data in `AnalysisResult`
- Test attaching GeoIP information to analysis results

## Testing
- `bash setup.sh`
- `cd nw_checker && bash ../flutter_env.sh`
- `pip install requests fastapi scapy apscheduler python-nmap pypdf`
- `pytest tests/test_dynamic_scan_analyze.py`
- `pytest` *(fails: The starlette.testclient module requires the httpx package to be installed.)*

------
https://chatgpt.com/codex/tasks/task_e_6895e1928f148323afac38a7b20a9cb4