### PR TITLE
feat: add OS/service banner scan

### DIFF
--- a/nw_checker/lib/static_scan_tab.dart
+++ b/nw_checker/lib/static_scan_tab.dart
@@ -60,6 +60,7 @@ class _StaticScanTabState extends State<StaticScanTab> {
     super.initState();
     _categories = [
       CategoryTile(title: 'Port Scan', icon: Icons.router),
+      CategoryTile(title: 'OS / Services', icon: Icons.computer),
       CategoryTile(title: 'SSL証明書', icon: Icons.security),
     ];
   }
@@ -97,8 +98,26 @@ class _StaticScanTabState extends State<StaticScanTab> {
           ..details =
               openPorts.map((p) => 'ポート $p: open').toList();
 
-        // 既存のSSL証明書タイルはダミー情報を表示
+        final osFinding = findings.firstWhere(
+          (f) => f['category'] == 'os_banner',
+          orElse: () => <String, dynamic>{},
+        );
+        final osName = osFinding['details']?['os'] as String? ?? '';
+        final bannerMap =
+            (osFinding['details']?['banners'] as Map? ?? {}).cast<String, dynamic>();
         _categories[1]
+          ..status =
+              (osName.isNotEmpty || bannerMap.isNotEmpty) ? ScanStatus.ok : ScanStatus.error
+          ..details = [
+            if (osName.isNotEmpty) 'OS: $osName',
+            ...bannerMap.entries
+                .map((e) => 'ポート ${e.key}: ${e.value}')
+                .toList(),
+            if (osName.isEmpty && bannerMap.isEmpty) '情報取得失敗',
+          ];
+
+        // 既存のSSL証明書タイルはダミー情報を表示
+        _categories[2]
           ..status = ScanStatus.warning
           ..details = ['証明書の期限が30日以内です'];
       });

--- a/nw_checker/test/static_scan_tab_flow_test.dart
+++ b/nw_checker/test/static_scan_tab_flow_test.dart
@@ -14,6 +14,13 @@ void main() {
             'open_ports': [22, 80],
           },
         },
+        {
+          'category': 'os_banner',
+          'details': {
+            'os': 'Linux',
+            'banners': {'22': 'ssh', '80': 'http'},
+          },
+        },
       ],
     };
   }
@@ -30,7 +37,7 @@ void main() {
     expect(find.text('スキャン未実施'), findsOneWidget);
     expect(find.byType(ListView), findsOneWidget);
     final initialChips = tester.widgetList<Chip>(find.byType(Chip)).toList();
-    expect(initialChips, hasLength(2));
+    expect(initialChips, hasLength(3));
     expect(initialChips.every((c) => c.backgroundColor == Colors.grey), isTrue);
 
     await tester.tap(find.byKey(const Key('staticButton')));
@@ -45,17 +52,22 @@ void main() {
 
     // Category order
     final portDy = tester.getTopLeft(find.text('Port Scan')).dy;
+    final osDy = tester.getTopLeft(find.text('OS / Services')).dy;
     final sslDy = tester.getTopLeft(find.text('SSL証明書')).dy;
-    expect(portDy < sslDy, isTrue);
+    expect(portDy < osDy, isTrue);
+    expect(osDy < sslDy, isTrue);
 
 // ステータスバッジと色
 final chipsAfter = tester.widgetList<Chip>(find.byType(Chip)).toList();
 final firstLabel = chipsAfter[0].label as Text;
 final secondLabel = chipsAfter[1].label as Text;
-expect(firstLabel.data, 'OK');
-expect(chipsAfter[0].backgroundColor, Colors.blueGrey);
-expect(secondLabel.data, '警告');
-expect(chipsAfter[1].backgroundColor, Colors.orange);
+final thirdLabel = chipsAfter[2].label as Text;
+expect(firstLabel.data, '警告');
+expect(chipsAfter[0].backgroundColor, Colors.orange);
+expect(secondLabel.data, 'OK');
+expect(chipsAfter[1].backgroundColor, Colors.blueGrey);
+expect(thirdLabel.data, '警告');
+expect(chipsAfter[2].backgroundColor, Colors.orange);
 
 // 警告ラベルが2つあること
 expect(find.text('警告'), findsNWidgets(2));
@@ -66,6 +78,11 @@ await tester.pumpAndSettle();
 expect(find.text('ポート 22: open'), findsOneWidget);
 expect(find.text('ポート 80: open'), findsOneWidget);
 
+    await tester.tap(find.text('OS / Services'));
+    await tester.pumpAndSettle();
+    expect(find.text('OS: Linux'), findsOneWidget);
+    expect(find.text('ポート 22: ssh'), findsOneWidget);
+    expect(find.text('ポート 80: http'), findsOneWidget);
 
     await tester.tap(find.text('SSL証明書'));
     await tester.pumpAndSettle();

--- a/nw_checker/test/static_scan_tab_test.dart
+++ b/nw_checker/test/static_scan_tab_test.dart
@@ -18,6 +18,10 @@ void main() {
             'category': 'ports',
             'details': {'open_ports': []},
           },
+          {
+            'category': 'os_banner',
+            'details': {'os': 'Linux', 'banners': {}},
+          },
         ],
       };
     }
@@ -30,7 +34,42 @@ void main() {
     await tester.pump();
     await tester.pumpAndSettle();
 
-    expect(find.text('OK'), findsOneWidget);
+    expect(find.text('OK'), findsNWidgets(2));
     expect(find.text('警告'), findsOneWidget);
+  });
+
+  testWidgets('no OS info shows error in tile', (tester) async {
+    Future<Map<String, dynamic>> mockScan() async {
+      return {
+        'summary': [],
+        'findings': [
+          {
+            'category': 'ports',
+            'details': {'open_ports': []},
+          },
+          {
+            'category': 'os_banner',
+            'details': {'os': '', 'banners': {}},
+          },
+        ],
+      };
+    }
+
+    await tester.pumpWidget(
+      MaterialApp(home: StaticScanTab(scanner: mockScan)),
+    );
+
+    await tester.tap(find.byKey(const Key('staticButton')));
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    final chips = tester.widgetList<Chip>(find.byType(Chip)).toList();
+    final osLabel = chips[1].label as Text;
+    expect(osLabel.data, 'エラー');
+    expect(chips[1].backgroundColor, Colors.red);
+
+    await tester.tap(find.text('OS / Services'));
+    await tester.pumpAndSettle();
+    expect(find.text('情報取得失敗'), findsOneWidget);
   });
 }

--- a/src/static_scan.py
+++ b/src/static_scan.py
@@ -34,8 +34,9 @@ def run_all(timeout: float = 5.0) -> Dict[str, List[Dict]]:
 
     findings: List[Dict] = []
     scanners = _load_scanners()
-    # ポートスキャンを最優先で実行するために先頭へ配置
-    scanners.sort(key=lambda x: 0 if x[0] == "ports" else 1)
+    # スキャン実行順序: ポートスキャン→OS/サービス→その他
+    order = {"ports": 0, "os_banner": 1}
+    scanners.sort(key=lambda x: order.get(x[0], 2))
 
     with ThreadPoolExecutor() as executor:
         future_map = {executor.submit(scan): name for name, scan in scanners}

--- a/tests/test_scan_modules.py
+++ b/tests/test_scan_modules.py
@@ -65,15 +65,35 @@ def test_ports_scan_no_open_ports(monkeypatch):
     assert result["details"]["open_ports"] == []
 
 
-def test_os_banner_scan_collects_banners(monkeypatch):
+def test_os_banner_scan_collects_os_and_banners(monkeypatch):
     class MockScanner:
         def scan(self, target, arguments=""):
-            return {"scan": {target: {"tcp": {"80": {"name": "http", "version": "Apache"}}}}}
+            return {
+                "scan": {
+                    target: {
+                        "tcp": {"80": {"name": "http", "version": "Apache"}},
+                        "osmatch": [{"name": "Linux"}],
+                    }
+                }
+            }
 
     monkeypatch.setattr(os_banner.nmap, "PortScanner", lambda: MockScanner())
     result = os_banner.scan("host")
-    assert result["score"] == 1
+    assert result["score"] == 2
     assert result["details"]["banners"] == {80: "http Apache"}
+    assert result["details"]["os"] == "Linux"
+
+
+def test_os_banner_scan_handles_no_results(monkeypatch):
+    class MockScanner:
+        def scan(self, target, arguments=""):
+            return {"scan": {target: {"tcp": {}, "osmatch": []}}}
+
+    monkeypatch.setattr(os_banner.nmap, "PortScanner", lambda: MockScanner())
+    result = os_banner.scan("host")
+    assert result["score"] == 0
+    assert result["details"]["banners"] == {}
+    assert result["details"]["os"] == ""
 
 
 def test_smb_netbios_scan_lists_open_ports(monkeypatch):

--- a/tests/test_static_scan.py
+++ b/tests/test_static_scan.py
@@ -110,3 +110,8 @@ def test_individual_scans_return_dict(module, category):
 def test_ports_result_is_first():
     results = static_scan.run_all()
     assert results["findings"][0]["category"] == "ports"
+
+
+def test_os_banner_result_is_second():
+    results = static_scan.run_all()
+    assert results["findings"][1]["category"] == "os_banner"


### PR DESCRIPTION
## Summary
- add nmap-based scanner to capture OS and service banners
- run OS/banner scan after port scan in static_scan
- show detected OS and services in new static scan UI tile
- expand unit tests for os/service scan and UI error state

## Testing
- `pip install -r requirements.txt`
- `pytest`
- `source flutter_env.sh && cd nw_checker && flutter test`


------
https://chatgpt.com/codex/tasks/task_e_6895ecd80f248323b3f9394eef1f2526