### PR TITLE
Add GeoIP lookup utility

### DIFF
--- a/tests/test_dynamic_scan_analyze.py
+++ b/tests/test_dynamic_scan_analyze.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 from datetime import datetime
+import types
 
 import pytest
 
@@ -18,6 +19,39 @@ def test_geoip_lookup(monkeypatch):
         "country": "Wonderland",
         "ip": "203.0.113.1",
     }
+
+
+def test_geoip_lookup_local_db(monkeypatch):
+    class FakeReader:
+        def __init__(self, path):
+            pass
+
+        def country(self, ip):
+            return types.SimpleNamespace(
+                country=types.SimpleNamespace(name="Wonderland")
+            )
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(
+        analyze.requests, "get", lambda *a, **k: pytest.fail("API called")
+    )
+    import geoip2.database
+
+    monkeypatch.setattr(geoip2.database, "Reader", FakeReader)
+    assert analyze.geoip_lookup("203.0.113.1") == {
+        "country": "Wonderland",
+        "ip": "203.0.113.1",
+    }
+
+
+def test_geoip_lookup_failure(monkeypatch):
+    class FailResp:
+        ok = False
+
+    monkeypatch.setattr(analyze.requests, "get", lambda url, timeout=5: FailResp())
+    assert analyze.geoip_lookup("203.0.113.1") == {}
 
 
 def test_reverse_dns_lookup(monkeypatch):
@@ -59,6 +93,27 @@ def test_assign_geoip_info(monkeypatch):
     pkt = type("Pkt", (), {"src_ip": "203.0.113.1", "dst_ip": "1.1.1.1"})
     res = analyze.assign_geoip_info(pkt)
     assert res.geoip == {"country": "Wonderland", "ip": "203.0.113.1"}
+
+
+def test_attach_geoip(monkeypatch):
+    class FakeResp:
+        ok = True
+
+        def json(self):  # pragma: no cover - 単純な dict 返却
+            return {"country_name": "Wonderland"}
+
+    monkeypatch.setattr(analyze.requests, "get", lambda url, timeout=5: FakeResp())
+    res = analyze.AnalysisResult()
+    updated = analyze.attach_geoip(res, "203.0.113.1")
+    assert updated.geoip == {"country": "Wonderland", "ip": "203.0.113.1"}
+    assert updated.src_ip == "203.0.113.1"
+
+
+def test_attach_geoip_no_ip():
+    res = analyze.AnalysisResult()
+    updated = analyze.attach_geoip(res, None)
+    assert updated.geoip is None
+    assert updated.src_ip is None
 
 
 def test_record_dns_history(monkeypatch):


### PR DESCRIPTION
## Summary
- Enhance geoip lookup with optional GeoIP2 database and external API fallback
- Add `attach_geoip` utility to store geoip data in `AnalysisResult`
- Test GeoIP database fallback, API failure, and attaching GeoIP without an IP address

## Testing
- `bash setup.sh`
- `cd nw_checker && bash ../flutter_env.sh`
- `pip install -r requirements.txt`
- `pytest tests/test_dynamic_scan_analyze.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895e1928f148323afac38a7b20a9cb4