### PR TITLE
Add SMB/NetBIOS probe with UI integration

### DIFF
--- a/nw_checker/test/static_scan_tab_flow_test.dart
+++ b/nw_checker/test/static_scan_tab_flow_test.dart
@@ -21,6 +21,13 @@ void main() {
             'banners': {'22': 'ssh', '80': 'http'},
           },
         },
+        {
+          'category': 'smb_netbios',
+          'details': {
+            'smb1_enabled': false,
+            'netbios_names': ['HOST'],
+          },
+        },
       ],
     };
   }
@@ -53,30 +60,30 @@ void main() {
     // Category order
     final portDy = tester.getTopLeft(find.text('Port Scan')).dy;
     final osDy = tester.getTopLeft(find.text('OS / Services')).dy;
-    final sslDy = tester.getTopLeft(find.text('SSL証明書')).dy;
+    final smbDy = tester.getTopLeft(find.text('SMB / NetBIOS')).dy;
     expect(portDy < osDy, isTrue);
-    expect(osDy < sslDy, isTrue);
+    expect(osDy < smbDy, isTrue);
 
-// ステータスバッジと色
-final chipsAfter = tester.widgetList<Chip>(find.byType(Chip)).toList();
-final firstLabel = chipsAfter[0].label as Text;
-final secondLabel = chipsAfter[1].label as Text;
-final thirdLabel = chipsAfter[2].label as Text;
-expect(firstLabel.data, '警告');
-expect(chipsAfter[0].backgroundColor, Colors.orange);
-expect(secondLabel.data, 'OK');
-expect(chipsAfter[1].backgroundColor, Colors.blueGrey);
-expect(thirdLabel.data, '警告');
-expect(chipsAfter[2].backgroundColor, Colors.orange);
+    // ステータスバッジと色
+    final chipsAfter = tester.widgetList<Chip>(find.byType(Chip)).toList();
+    final firstLabel = chipsAfter[0].label as Text;
+    final secondLabel = chipsAfter[1].label as Text;
+    final thirdLabel = chipsAfter[2].label as Text;
+    expect(firstLabel.data, '警告');
+    expect(chipsAfter[0].backgroundColor, Colors.orange);
+    expect(secondLabel.data, 'OK');
+    expect(chipsAfter[1].backgroundColor, Colors.blueGrey);
+    expect(thirdLabel.data, 'OK');
+    expect(chipsAfter[2].backgroundColor, Colors.blueGrey);
 
-// 警告ラベルが2つあること
-expect(find.text('警告'), findsNWidgets(2));
+    // 警告ラベルが1つあること
+    expect(find.text('警告'), findsOneWidget);
 
-// ポートスキャン結果の表示確認
-await tester.tap(find.text('Port Scan'));
-await tester.pumpAndSettle();
-expect(find.text('ポート 22: open'), findsOneWidget);
-expect(find.text('ポート 80: open'), findsOneWidget);
+    // ポートスキャン結果の表示確認
+    await tester.tap(find.text('Port Scan'));
+    await tester.pumpAndSettle();
+    expect(find.text('ポート 22: open'), findsOneWidget);
+    expect(find.text('ポート 80: open'), findsOneWidget);
 
     await tester.tap(find.text('OS / Services'));
     await tester.pumpAndSettle();
@@ -84,8 +91,9 @@ expect(find.text('ポート 80: open'), findsOneWidget);
     expect(find.text('ポート 22: ssh'), findsOneWidget);
     expect(find.text('ポート 80: http'), findsOneWidget);
 
-    await tester.tap(find.text('SSL証明書'));
+    await tester.tap(find.text('SMB / NetBIOS'));
     await tester.pumpAndSettle();
-    expect(find.text('証明書の期限が30日以内です'), findsOneWidget);
+    expect(find.text('SMBv1: 無効'), findsOneWidget);
+    expect(find.text('NetBIOS: HOST'), findsOneWidget);
   });
 }

--- a/nw_checker/test/static_scan_tab_test.dart
+++ b/nw_checker/test/static_scan_tab_test.dart
@@ -22,6 +22,10 @@ void main() {
             'category': 'os_banner',
             'details': {'os': 'Linux', 'banners': {}},
           },
+          {
+            'category': 'smb_netbios',
+            'details': {'smb1_enabled': false, 'netbios_names': []},
+          },
         ],
       };
     }
@@ -34,8 +38,8 @@ void main() {
     await tester.pump();
     await tester.pumpAndSettle();
 
-    expect(find.text('OK'), findsNWidgets(2));
-    expect(find.text('警告'), findsOneWidget);
+    expect(find.text('OK'), findsNWidgets(3));
+    expect(find.text('警告'), findsNothing);
   });
 
   testWidgets('no OS info shows error in tile', (tester) async {
@@ -50,6 +54,10 @@ void main() {
           {
             'category': 'os_banner',
             'details': {'os': '', 'banners': {}},
+          },
+          {
+            'category': 'smb_netbios',
+            'details': {'smb1_enabled': false, 'netbios_names': []},
           },
         ],
       };
@@ -71,5 +79,39 @@ void main() {
     await tester.tap(find.text('OS / Services'));
     await tester.pumpAndSettle();
     expect(find.text('情報取得失敗'), findsOneWidget);
+  });
+
+  testWidgets('SMBv1 enabled shows warning in tile', (tester) async {
+    Future<Map<String, dynamic>> mockScan() async {
+      return {
+        'summary': [],
+        'findings': [
+          {
+            'category': 'ports',
+            'details': {'open_ports': []},
+          },
+          {
+            'category': 'os_banner',
+            'details': {'os': 'Linux', 'banners': {}},
+          },
+          {
+            'category': 'smb_netbios',
+            'details': {'smb1_enabled': true, 'netbios_names': []},
+          },
+        ],
+      };
+    }
+
+    await tester.pumpWidget(
+      MaterialApp(home: StaticScanTab(scanner: mockScan)),
+    );
+
+    await tester.tap(find.byKey(const Key('staticButton')));
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    final chips = tester.widgetList<Chip>(find.byType(Chip)).toList();
+    final smbLabel = chips[2].label as Text;
+    expect(smbLabel.data, '警告');
   });
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ reportlab==4.4.3
 pypdf==5.9.0
 apscheduler==3.11.0
 pytest-benchmark==5.1.0
+impacket==0.11.0

--- a/tests/test_scan_modules.py
+++ b/tests/test_scan_modules.py
@@ -96,22 +96,31 @@ def test_os_banner_scan_handles_no_results(monkeypatch):
     assert result["details"]["os"] == ""
 
 
-def test_smb_netbios_scan_lists_open_ports(monkeypatch):
-    class MockScanner:
-        def scan(self, target, arguments=""):
-            return {
-                "scan": {
-                    target: {
-                        "tcp": {"445": {"state": "open"}},
-                        "udp": {"137": {"state": "open"}, "138": {"state": "closed"}},
-                    }
-                }
-            }
+def test_smb_netbios_scan_detects_smb1(monkeypatch):
+    class DummyNB:
+        def queryIPForName(self, target, timeout=2):  # noqa: D401, ARG002
+            return ["HOST"]
 
-    monkeypatch.setattr(smb_netbios.nmap, "PortScanner", lambda: MockScanner())
+        def close(self):
+            pass
+
+    class DummyConn:
+        def __init__(self, *args, **kwargs):  # noqa: D401, ARG002
+            pass
+
+        def getDialect(self):
+            return 0x0000  # SMBv1
+
+        def logoff(self):
+            pass
+
+    monkeypatch.setattr(smb_netbios, "NetBIOS", lambda: DummyNB())
+    monkeypatch.setattr(smb_netbios, "SMBConnection", DummyConn)
+
     result = smb_netbios.scan("host")
-    assert result["score"] == 2
-    assert set(result["details"]["open_ports"]) == {445, 137}
+    assert result["score"] == 5
+    assert result["details"]["smb1_enabled"] is True
+    assert result["details"]["netbios_names"] == ["HOST"]
 
 
 # --- scapy based scans ---------------------------------------------------


### PR DESCRIPTION
## Summary
- probe SMB/NetBIOS via impacket to detect SMBv1 and NetBIOS names
- surface SMB findings in third tile of static scan UI
- cover SMB scan and UI logic with tests

## Testing
- `pytest -q`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_6899975d41d883239a533ddb77fa212a