### PR TITLE
feat: alert on blacklisted reverse DNS

### DIFF
--- a/tests/test_dynamic_scan_analyze.py
+++ b/tests/test_dynamic_scan_analyze.py
@@ -21,7 +21,18 @@ def test_geoip_lookup(monkeypatch):
 
 
 def test_reverse_dns_lookup(monkeypatch):
+    analyze._dns_history.clear()
     monkeypatch.setattr(analyze.socket, "gethostbyaddr", lambda ip: ("host.example", [], []))
+    assert analyze.reverse_dns_lookup("1.1.1.1") == "host.example"
+    assert analyze._dns_history["1.1.1.1"] == "host.example"
+
+
+def test_reverse_dns_lookup_cached(monkeypatch):
+    analyze._dns_history.clear()
+    monkeypatch.setattr(analyze.socket, "gethostbyaddr", lambda ip: ("host.example", [], []))
+    analyze.reverse_dns_lookup("1.1.1.1")
+    # キャッシュが使われるため、以降のソケット呼び出しは発生しない
+    monkeypatch.setattr(analyze.socket, "gethostbyaddr", lambda ip: (_ for _ in ()).throw(AssertionError))
     assert analyze.reverse_dns_lookup("1.1.1.1") == "host.example"
 
 
@@ -77,10 +88,12 @@ def test_attach_geoip(monkeypatch):
 
 def test_record_dns_history(monkeypatch):
     analyze._dns_history.clear()
-    monkeypatch.setattr(analyze, "reverse_dns_lookup", lambda ip: "host.example")
+    analyze.DNS_BLACKLIST.clear()
+    monkeypatch.setattr(analyze.socket, "gethostbyaddr", lambda ip: ("host.example", [], []))
     pkt = type("Pkt", (), {"src_ip": "1.1.1.1"})
     res = analyze.record_dns_history(pkt)
     assert res.reverse_dns == "host.example"
+    assert res.reverse_dns_blacklisted is False
     assert analyze._dns_history["1.1.1.1"] == "host.example"
 
 
@@ -116,7 +129,42 @@ def test_record_dns_history_no_hostname(monkeypatch):
     pkt = type("Pkt", (), {"src_ip": "1.1.1.1"})
     res = analyze.record_dns_history(pkt)
     assert res.reverse_dns is None
+    assert res.reverse_dns_blacklisted is None
     assert analyze._dns_history == {}
+
+
+def test_record_dns_history_blacklisted(monkeypatch):
+    analyze._dns_history.clear()
+    analyze.DNS_BLACKLIST.clear()
+    analyze.DNS_BLACKLIST.add("bad.example")
+    monkeypatch.setattr(analyze.socket, "gethostbyaddr", lambda ip: ("bad.example", [], []))
+    pkt = type("Pkt", (), {"src_ip": "2.2.2.2"})
+    res = analyze.record_dns_history(pkt)
+    assert res.reverse_dns == "bad.example"
+    assert res.reverse_dns_blacklisted is True
+
+
+def test_record_dns_history_blacklisted_cached(monkeypatch):
+    analyze._dns_history.clear()
+    analyze.DNS_BLACKLIST.clear()
+    analyze.DNS_BLACKLIST.add("bad.example")
+
+    # 1回目の呼び出しで DNS を解決して履歴に保存
+    monkeypatch.setattr(
+        analyze.socket, "gethostbyaddr", lambda ip: ("bad.example", [], [])
+    )
+    pkt = type("Pkt", (), {"src_ip": "3.3.3.3"})
+    analyze.record_dns_history(pkt)
+
+    # キャッシュされた結果を利用するため、ソケットは呼び出されない
+    monkeypatch.setattr(
+        analyze.socket,
+        "gethostbyaddr",
+        lambda ip: (_ for _ in ()).throw(AssertionError),
+    )
+    res_cached = analyze.record_dns_history(pkt)
+    assert res_cached.reverse_dns == "bad.example"
+    assert res_cached.reverse_dns_blacklisted is True
 
 
 def test_detect_dangerous_protocols_safe_protocol():


### PR DESCRIPTION
## Summary
- cache reverse DNS lookups and store history
- flag packets when reverse DNS host is on blacklist
- add tests for DNS caching and blacklist alerts

## Testing
- `nw_checker/.venv/bin/pytest`


------
https://chatgpt.com/codex/tasks/task_e_68999772a3d08323ad292a20026c719d