### PR TITLE
Add UPnP scan and UI integration

### DIFF
--- a/nw_checker/lib/static_scan_tab.dart
+++ b/nw_checker/lib/static_scan_tab.dart
@@ -62,6 +62,7 @@ class _StaticScanTabState extends State<StaticScanTab> {
       CategoryTile(title: 'Port Scan', icon: Icons.router),
       CategoryTile(title: 'OS / Services', icon: Icons.computer),
       CategoryTile(title: 'SMB / NetBIOS', icon: Icons.folder),
+      CategoryTile(title: 'UPnP', icon: Icons.cast),
     ];
   }
 
@@ -137,6 +138,25 @@ class _StaticScanTabState extends State<StaticScanTab> {
             if (smb1 != null) 'SMBv1: ${smb1 ? '有効' : '無効'}',
             ...smbNames.map((n) => 'NetBIOS: $n'),
             if (smbError != null) '情報取得失敗',
+          ];
+
+        final upnpFinding = findings.firstWhere(
+          (f) => f['category'] == 'upnp',
+          orElse: () => <String, dynamic>{},
+        );
+        final upnpDetails =
+            (upnpFinding['details'] as Map?)?.cast<String, dynamic>() ?? {};
+        final upnpWarnings =
+            (upnpDetails['warnings'] as List? ?? []).cast<String>();
+        final upnpResponders =
+            (upnpDetails['responders'] as List? ?? []).cast<String>();
+        _categories[3]
+          ..status =
+              upnpWarnings.isEmpty ? ScanStatus.ok : ScanStatus.warning
+          ..details = [
+            ...upnpWarnings,
+            ...upnpResponders.map((ip) => 'ホスト $ip'),
+            if (upnpWarnings.isEmpty && upnpResponders.isEmpty) '応答なし',
           ];
       });
     });

--- a/nw_checker/test/static_scan_tab_flow_test.dart
+++ b/nw_checker/test/static_scan_tab_flow_test.dart
@@ -28,6 +28,13 @@ void main() {
             'netbios_names': ['HOST'],
           },
         },
+        {
+          'category': 'upnp',
+          'details': {
+            'responders': ['1.1.1.1'],
+            'warnings': ['UPnP service responded from 1.1.1.1'],
+          },
+        },
       ],
     };
   }
@@ -44,7 +51,7 @@ void main() {
     expect(find.text('スキャン未実施'), findsOneWidget);
     expect(find.byType(ListView), findsOneWidget);
     final initialChips = tester.widgetList<Chip>(find.byType(Chip)).toList();
-    expect(initialChips, hasLength(3));
+    expect(initialChips, hasLength(4));
     expect(initialChips.every((c) => c.backgroundColor == Colors.grey), isTrue);
 
     await tester.tap(find.byKey(const Key('staticButton')));
@@ -61,23 +68,28 @@ void main() {
     final portDy = tester.getTopLeft(find.text('Port Scan')).dy;
     final osDy = tester.getTopLeft(find.text('OS / Services')).dy;
     final smbDy = tester.getTopLeft(find.text('SMB / NetBIOS')).dy;
+    final upnpDy = tester.getTopLeft(find.text('UPnP')).dy;
     expect(portDy < osDy, isTrue);
     expect(osDy < smbDy, isTrue);
+    expect(smbDy < upnpDy, isTrue);
 
     // ステータスバッジと色
     final chipsAfter = tester.widgetList<Chip>(find.byType(Chip)).toList();
     final firstLabel = chipsAfter[0].label as Text;
     final secondLabel = chipsAfter[1].label as Text;
     final thirdLabel = chipsAfter[2].label as Text;
+    final fourthLabel = chipsAfter[3].label as Text;
     expect(firstLabel.data, '警告');
     expect(chipsAfter[0].backgroundColor, Colors.orange);
     expect(secondLabel.data, 'OK');
     expect(chipsAfter[1].backgroundColor, Colors.blueGrey);
     expect(thirdLabel.data, 'OK');
     expect(chipsAfter[2].backgroundColor, Colors.blueGrey);
+    expect(fourthLabel.data, '警告');
+    expect(chipsAfter[3].backgroundColor, Colors.orange);
 
-    // 警告ラベルが1つあること
-    expect(find.text('警告'), findsOneWidget);
+    // 警告ラベルが2つあること
+    expect(find.text('警告'), findsNWidgets(2));
 
     // ポートスキャン結果の表示確認
     await tester.tap(find.text('Port Scan'));
@@ -95,5 +107,9 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('SMBv1: 無効'), findsOneWidget);
     expect(find.text('NetBIOS: HOST'), findsOneWidget);
+
+    await tester.tap(find.text('UPnP'));
+    await tester.pumpAndSettle();
+    expect(find.text('UPnP service responded from 1.1.1.1'), findsOneWidget);
   });
 }

--- a/nw_checker/test/static_scan_tab_test.dart
+++ b/nw_checker/test/static_scan_tab_test.dart
@@ -26,6 +26,10 @@ void main() {
             'category': 'smb_netbios',
             'details': {'smb1_enabled': false, 'netbios_names': []},
           },
+          {
+            'category': 'upnp',
+            'details': {'responders': [], 'warnings': []},
+          },
         ],
       };
     }
@@ -38,7 +42,7 @@ void main() {
     await tester.pump();
     await tester.pumpAndSettle();
 
-    expect(find.text('OK'), findsNWidgets(3));
+    expect(find.text('OK'), findsNWidgets(4));
     expect(find.text('警告'), findsNothing);
   });
 
@@ -58,6 +62,10 @@ void main() {
           {
             'category': 'smb_netbios',
             'details': {'smb1_enabled': false, 'netbios_names': []},
+          },
+          {
+            'category': 'upnp',
+            'details': {'responders': [], 'warnings': []},
           },
         ],
       };
@@ -98,6 +106,10 @@ void main() {
             'category': 'smb_netbios',
             'details': {'smb1_enabled': true, 'netbios_names': []},
           },
+          {
+            'category': 'upnp',
+            'details': {'responders': [], 'warnings': []},
+          },
         ],
       };
     }
@@ -113,5 +125,49 @@ void main() {
     final chips = tester.widgetList<Chip>(find.byType(Chip)).toList();
     final smbLabel = chips[2].label as Text;
     expect(smbLabel.data, '警告');
+  });
+
+  testWidgets('UPnP responder shows warning in tile', (tester) async {
+    Future<Map<String, dynamic>> mockScan() async {
+      return {
+        'summary': [],
+        'findings': [
+          {
+            'category': 'ports',
+            'details': {'open_ports': []},
+          },
+          {
+            'category': 'os_banner',
+            'details': {'os': 'Linux', 'banners': {}},
+          },
+          {
+            'category': 'smb_netbios',
+            'details': {'smb1_enabled': false, 'netbios_names': []},
+          },
+          {
+            'category': 'upnp',
+            'details': {
+              'responders': ['1.1.1.1'],
+              'warnings': ['UPnP service responded from 1.1.1.1'],
+            },
+          },
+        ],
+      };
+    }
+
+    await tester.pumpWidget(
+      MaterialApp(home: StaticScanTab(scanner: mockScan)),
+    );
+
+    await tester.tap(find.byKey(const Key('staticButton')));
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    final chips = tester.widgetList<Chip>(find.byType(Chip)).toList();
+    final upnpLabel = chips[3].label as Text;
+    expect(upnpLabel.data, '警告');
+    await tester.tap(find.text('UPnP'));
+    await tester.pumpAndSettle();
+    expect(find.text('UPnP service responded from 1.1.1.1'), findsOneWidget);
   });
 }

--- a/src/scans/upnp.py
+++ b/src/scans/upnp.py
@@ -4,11 +4,7 @@ from scapy.all import IP, UDP, Raw, sr1  # type: ignore
 
 
 def scan(target: str = "239.255.255.250") -> dict:
-    """Send an SSDP M-SEARCH and record any response.
-
-    The function gracefully handles environments where raw sockets are not
-    permitted by returning an empty result.
-    """
+    """Send an SSDP M-SEARCH and evaluate responses."""
 
     query = (
         "M-SEARCH * HTTP/1.1\r\n"
@@ -17,18 +13,26 @@ def scan(target: str = "239.255.255.250") -> dict:
         "MX: 1\r\n"
         "ST: ssdp:all\r\n\r\n"
     )
+
     responders = []
+    warnings = []
     try:
         pkt = IP(dst=target) / UDP(sport=1900, dport=1900) / Raw(load=query)
         ans = sr1(pkt, timeout=1, verbose=False)
         if ans:
-            responders.append(ans.src)
+            src = getattr(ans, "src", "")
+            responders.append(src)
+            payload = bytes(getattr(ans, "load", b""))
+            if b"upnp" in payload.lower():
+                warnings.append(f"UPnP service responded from {src}")
+            else:
+                warnings.append(f"Misconfigured SSDP response from {src}")
     except Exception:  # pragma: no cover
         pass
 
     return {
         "category": "upnp",
-        "score": len(responders),
-        "details": {"responders": responders},
+        "score": len(warnings),
+        "details": {"responders": responders, "warnings": warnings},
     }
 

--- a/tests/test_scan_modules.py
+++ b/tests/test_scan_modules.py
@@ -125,11 +125,25 @@ def test_smb_netbios_scan_detects_smb1(monkeypatch):
 
 # --- scapy based scans ---------------------------------------------------
 
-def test_upnp_scan_records_responder(monkeypatch):
-    monkeypatch.setattr(upnp, "sr1", lambda *_, **__: SimpleNamespace(src="1.2.3.4"))
+
+def test_upnp_scan_flags_open_service(monkeypatch):
+    response = SimpleNamespace(
+        src="1.2.3.4", load=b"HTTP/1.1 200 OK\r\nSERVER: upnp\r\n\r\n"
+    )
+    monkeypatch.setattr(upnp, "sr1", lambda *_, **__: response)
     result = upnp.scan()
     assert result["score"] == 1
     assert result["details"]["responders"] == ["1.2.3.4"]
+    assert "1.2.3.4" in result["details"]["warnings"][0]
+
+
+def test_upnp_scan_flags_misconfigured(monkeypatch):
+    response = SimpleNamespace(src="5.6.7.8", load=b"BAD RESPONSE")
+    monkeypatch.setattr(upnp, "sr1", lambda *_, **__: response)
+    result = upnp.scan()
+    assert result["score"] == 1
+    assert result["details"]["responders"] == ["5.6.7.8"]
+    assert "Misconfigured" in result["details"]["warnings"][0]
 
 
 def test_dns_scan_collects_answers(monkeypatch):


### PR DESCRIPTION
## Summary
- implement UPnP/SSDP scan that flags open or misconfigured services
- display UPnP scan results in new static scan tile
- add unit tests for UPnP scan and updated UI

## Testing
- `pytest tests/test_scan_modules.py::test_upnp_scan_flags_open_service tests/test_scan_modules.py::test_upnp_scan_flags_misconfigured`
- `flutter test` *(fails: process interrupted during execution)*

------
https://chatgpt.com/codex/tasks/task_e_68999b0e730c8323916cf3010baf34a6