### PR TITLE
feat: handle optional protocol detection

### DIFF
--- a/src/dynamic_scan/analyze.py
+++ b/src/dynamic_scan/analyze.py
@@ -90,8 +90,12 @@ def reverse_dns_lookup(ip: str) -> str | None:
         return None
 
 
-def is_dangerous_protocol(protocol: str) -> bool:
-    """危険プロトコルか判定する。"""
+def is_dangerous_protocol(protocol: str | None) -> bool:
+    """危険プロトコルか判定する。
+    文字列以外が渡された場合は危険ではないとみなす。
+    """
+    if not isinstance(protocol, str):
+        return False
     return protocol.lower() in DANGEROUS_PROTOCOLS
 
 

--- a/tests/test_dynamic_scan.py
+++ b/tests/test_dynamic_scan.py
@@ -28,6 +28,7 @@ def test_reverse_dns_lookup(monkeypatch):
 def test_is_dangerous_protocol():
     assert analyze.is_dangerous_protocol("telnet")
     assert not analyze.is_dangerous_protocol("http")
+    assert not analyze.is_dangerous_protocol(None)
 
 
 def test_is_unapproved_device():

--- a/tests/test_dynamic_scan_analyze.py
+++ b/tests/test_dynamic_scan_analyze.py
@@ -73,6 +73,7 @@ def test_reverse_dns_lookup_cached(monkeypatch):
 def test_is_dangerous_protocol():
     assert analyze.is_dangerous_protocol("telnet")
     assert not analyze.is_dangerous_protocol("http")
+    assert not analyze.is_dangerous_protocol(None)
 
 
 def test_is_unapproved_device():


### PR DESCRIPTION
## Summary
- guard `is_dangerous_protocol` against non-string inputs
- cover `None` protocol cases in dynamic scan tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68999b1581ec8323927081b18c077114