### PR TITLE
feat: add ARP spoof detection and UI tile

### DIFF
--- a/nw_checker/lib/static_scan_tab.dart
+++ b/nw_checker/lib/static_scan_tab.dart
@@ -58,11 +58,12 @@ class _StaticScanTabState extends State<StaticScanTab> {
   @override
   void initState() {
     super.initState();
-    _categories = [
+      _categories = [
       CategoryTile(title: 'Port Scan', icon: Icons.router),
       CategoryTile(title: 'OS / Services', icon: Icons.computer),
       CategoryTile(title: 'SMB / NetBIOS', icon: Icons.folder),
       CategoryTile(title: 'UPnP', icon: Icons.cast),
+      CategoryTile(title: 'ARP Spoof', icon: Icons.security),
     ];
   }
 
@@ -157,6 +158,22 @@ class _StaticScanTabState extends State<StaticScanTab> {
             ...upnpWarnings,
             ...upnpResponders.map((ip) => 'ホスト $ip'),
             if (upnpWarnings.isEmpty && upnpResponders.isEmpty) '応答なし',
+          ];
+
+        final arpFinding = findings.firstWhere(
+          (f) => f['category'] == 'arp_spoof',
+          orElse: () => <String, dynamic>{},
+        );
+        final arpDetails =
+            (arpFinding['details'] as Map?)?.cast<String, dynamic>() ?? {};
+        final arpVuln = arpDetails['vulnerable'] as bool?;
+        final arpExplain = arpDetails['explanation'] as String?;
+        _categories[4]
+          ..status = arpVuln == null
+              ? ScanStatus.error
+              : (arpVuln ? ScanStatus.warning : ScanStatus.ok)
+          ..details = [
+            if (arpExplain != null) arpExplain else '情報取得失敗',
           ];
       });
     });

--- a/nw_checker/test/static_scan_tab_flow_test.dart
+++ b/nw_checker/test/static_scan_tab_flow_test.dart
@@ -35,6 +35,13 @@ void main() {
             'warnings': ['UPnP service responded from 1.1.1.1'],
           },
         },
+        {
+          'category': 'arp_spoof',
+          'details': {
+            'vulnerable': true,
+            'explanation': 'ARP table updated with spoofed entry',
+          },
+        },
       ],
     };
   }
@@ -51,7 +58,7 @@ void main() {
     expect(find.text('スキャン未実施'), findsOneWidget);
     expect(find.byType(ListView), findsOneWidget);
     final initialChips = tester.widgetList<Chip>(find.byType(Chip)).toList();
-    expect(initialChips, hasLength(4));
+    expect(initialChips, hasLength(5));
     expect(initialChips.every((c) => c.backgroundColor == Colors.grey), isTrue);
 
     await tester.tap(find.byKey(const Key('staticButton')));
@@ -69,9 +76,11 @@ void main() {
     final osDy = tester.getTopLeft(find.text('OS / Services')).dy;
     final smbDy = tester.getTopLeft(find.text('SMB / NetBIOS')).dy;
     final upnpDy = tester.getTopLeft(find.text('UPnP')).dy;
+    final arpDy = tester.getTopLeft(find.text('ARP Spoof')).dy;
     expect(portDy < osDy, isTrue);
     expect(osDy < smbDy, isTrue);
     expect(smbDy < upnpDy, isTrue);
+    expect(upnpDy < arpDy, isTrue);
 
     // ステータスバッジと色
     final chipsAfter = tester.widgetList<Chip>(find.byType(Chip)).toList();
@@ -79,6 +88,7 @@ void main() {
     final secondLabel = chipsAfter[1].label as Text;
     final thirdLabel = chipsAfter[2].label as Text;
     final fourthLabel = chipsAfter[3].label as Text;
+    final fifthLabel = chipsAfter[4].label as Text;
     expect(firstLabel.data, '警告');
     expect(chipsAfter[0].backgroundColor, Colors.orange);
     expect(secondLabel.data, 'OK');
@@ -87,9 +97,11 @@ void main() {
     expect(chipsAfter[2].backgroundColor, Colors.blueGrey);
     expect(fourthLabel.data, '警告');
     expect(chipsAfter[3].backgroundColor, Colors.orange);
+    expect(fifthLabel.data, '警告');
+    expect(chipsAfter[4].backgroundColor, Colors.orange);
 
-    // 警告ラベルが2つあること
-    expect(find.text('警告'), findsNWidgets(2));
+    // 警告ラベルが3つあること
+    expect(find.text('警告'), findsNWidgets(3));
 
     // ポートスキャン結果の表示確認
     await tester.tap(find.text('Port Scan'));
@@ -111,5 +123,12 @@ void main() {
     await tester.tap(find.text('UPnP'));
     await tester.pumpAndSettle();
     expect(find.text('UPnP service responded from 1.1.1.1'), findsOneWidget);
+
+    await tester.tap(find.text('ARP Spoof'));
+    await tester.pumpAndSettle();
+    expect(
+      find.text('ARP table updated with spoofed entry'),
+      findsOneWidget,
+    );
   });
 }

--- a/nw_checker/test/static_scan_tab_test.dart
+++ b/nw_checker/test/static_scan_tab_test.dart
@@ -30,6 +30,13 @@ void main() {
             'category': 'upnp',
             'details': {'responders': [], 'warnings': []},
           },
+          {
+            'category': 'arp_spoof',
+            'details': {
+              'vulnerable': false,
+              'explanation': 'No ARP poisoning detected',
+            },
+          },
         ],
       };
     }
@@ -42,7 +49,7 @@ void main() {
     await tester.pump();
     await tester.pumpAndSettle();
 
-    expect(find.text('OK'), findsNWidgets(4));
+    expect(find.text('OK'), findsNWidgets(5));
     expect(find.text('警告'), findsNothing);
   });
 
@@ -66,6 +73,13 @@ void main() {
           {
             'category': 'upnp',
             'details': {'responders': [], 'warnings': []},
+          },
+          {
+            'category': 'arp_spoof',
+            'details': {
+              'vulnerable': false,
+              'explanation': 'No ARP poisoning detected',
+            },
           },
         ],
       };
@@ -110,6 +124,13 @@ void main() {
             'category': 'upnp',
             'details': {'responders': [], 'warnings': []},
           },
+          {
+            'category': 'arp_spoof',
+            'details': {
+              'vulnerable': false,
+              'explanation': 'No ARP poisoning detected',
+            },
+          },
         ],
       };
     }
@@ -149,6 +170,13 @@ void main() {
             'details': {
               'responders': ['1.1.1.1'],
               'warnings': ['UPnP service responded from 1.1.1.1'],
+            },
+          },
+          {
+            'category': 'arp_spoof',
+            'details': {
+              'vulnerable': false,
+              'explanation': 'No ARP poisoning detected',
             },
           },
         ],

--- a/src/scans/arp_spoof.py
+++ b/src/scans/arp_spoof.py
@@ -1,29 +1,69 @@
-"""Static scan for ARP spoofing attempts using scapy."""
+"""Active ARP spoofing test using scapy."""
 
-from scapy.all import sniff, ARP  # type: ignore
+from __future__ import annotations
+
+import re
+import subprocess
+import time
+from typing import Dict
+
+from scapy.all import ARP, send  # type: ignore
 
 
-def scan(timeout: int = 2) -> dict:
-    """Sniff ARP replies briefly and look for conflicting MAC addresses."""
+# デフォルトで注入するダミーのIPとMAC
+FAKE_IP = "1.2.3.4"
+FAKE_MAC = "de:ad:be:ef:00:01"
 
-    suspects = set()
+
+def _get_arp_table() -> Dict[str, str]:
+    """Parse system ARP table into an ``ip -> mac`` mapping."""
+
     try:
-        packets = sniff(filter="arp", timeout=timeout)
-        seen = {}
-        for pkt in packets:
-            if ARP in pkt and pkt[ARP].op == 2:  # is-at
-                ip = pkt[ARP].psrc
-                mac = pkt[ARP].hwsrc
-                if ip in seen and seen[ip] != mac:
-                    suspects.add(ip)
-                else:
-                    seen[ip] = mac
-    except Exception:  # pragma: no cover
-        pass
+        output = subprocess.check_output(["arp", "-an"], text=True)
+    except Exception:  # pragma: no cover - OSに依存するため
+        return {}
+
+    table: Dict[str, str] = {}
+    for line in output.splitlines():
+        m = re.search(r"\((\d+\.\d+\.\d+\.\d+)\) at ([0-9a-f:]{17})", line, re.I)
+        if m:
+            table[m.group(1)] = m.group(2)
+    return table
+
+
+def scan(wait: float = 1.0) -> dict:
+    """Inject a spoofed ARP reply and watch for table changes."""
+
+    before = _get_arp_table()
+
+    try:
+        pkt = ARP(
+            op=2,  # is-at
+            psrc=FAKE_IP,
+            hwsrc=FAKE_MAC,
+            pdst=FAKE_IP,
+            hwdst="ff:ff:ff:ff:ff:ff",
+        )
+        send(pkt, verbose=False)
+        time.sleep(wait)
+    except Exception as exc:  # pragma: no cover - 実行環境による
+        return {
+            "category": "arp_spoof",
+            "score": 0,
+            "details": {"error": str(exc)},
+        }
+
+    after = _get_arp_table()
+    changed = before.get(FAKE_IP) != FAKE_MAC and after.get(FAKE_IP) == FAKE_MAC
+    explanation = (
+        "ARP table updated with spoofed entry"
+        if changed
+        else "No ARP poisoning detected"
+    )
 
     return {
         "category": "arp_spoof",
-        "score": len(suspects),
-        "details": {"suspects": list(suspects)},
+        "score": 5 if changed else 0,
+        "details": {"vulnerable": changed, "explanation": explanation},
     }
 

--- a/src/static_scan.py
+++ b/src/static_scan.py
@@ -35,7 +35,7 @@ def run_all(timeout: float = 5.0) -> Dict[str, List[Dict]]:
     findings: List[Dict] = []
     scanners = _load_scanners()
     # スキャン実行順序: ポートスキャン→OS/サービス→その他
-    order = {"ports": 0, "os_banner": 1}
+    order = {"ports": 0, "os_banner": 1, "dhcp": 2, "dns": 3, "arp_spoof": 4}
     scanners.sort(key=lambda x: order.get(x[0], 2))
 
     with ThreadPoolExecutor() as executor:

--- a/tests/test_scan_modules.py
+++ b/tests/test_scan_modules.py
@@ -228,23 +228,24 @@ def test_dhcp_scan_detects_servers(monkeypatch):
     assert result["details"]["servers"] == ["10.0.0.1"]
 
 
-def test_arp_spoof_scan_finds_conflicts(monkeypatch):
-    class FakePkt:
-        def __init__(self, ip, mac):
-            self.ip = ip
-            self.mac = mac
+def test_arp_spoof_scan_detects_table_change(monkeypatch):
+    tables = [
+        {"1.2.3.4": "aa:aa"},
+        {"1.2.3.4": arp_spoof.FAKE_MAC},
+    ]
+    monkeypatch.setattr(arp_spoof, "_get_arp_table", lambda: tables.pop(0))
+    monkeypatch.setattr(arp_spoof, "send", lambda *_, **__: None)
+    result = arp_spoof.scan(wait=0)
+    assert result["score"] == 5
+    assert result["details"]["vulnerable"] is True
 
-        def __contains__(self, item):
-            return True
 
-        def __getitem__(self, layer):
-            return SimpleNamespace(op=2, psrc=self.ip, hwsrc=self.mac)
-
-    packets = [FakePkt("1.1.1.1", "aa:aa"), FakePkt("1.1.1.1", "bb:bb")]
-    monkeypatch.setattr(arp_spoof, "sniff", lambda *_, **__: packets)
-    result = arp_spoof.scan()
-    assert result["score"] == 1
-    assert result["details"]["suspects"] == ["1.1.1.1"]
+def test_arp_spoof_scan_no_change(monkeypatch):
+    monkeypatch.setattr(arp_spoof, "_get_arp_table", lambda: {"1.2.3.4": "aa:aa"})
+    monkeypatch.setattr(arp_spoof, "send", lambda *_, **__: None)
+    result = arp_spoof.scan(wait=0)
+    assert result["score"] == 0
+    assert result["details"]["vulnerable"] is False
 
 
 # --- SSL certificate -----------------------------------------------------


### PR DESCRIPTION
## Summary
- actively inject spoofed ARP replies and watch for ARP table changes
- surface ARP spoof findings in fifth static scan tile
- test ARP spoof detection and updated UI

## Testing
- `pytest -q`
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_6899a0c4b16c8323967fa865b882c101