### PR TITLE
Add DHCP scan and UI integration

### DIFF
--- a/nw_checker/lib/static_scan_tab.dart
+++ b/nw_checker/lib/static_scan_tab.dart
@@ -64,6 +64,7 @@ class _StaticScanTabState extends State<StaticScanTab> {
       CategoryTile(title: 'SMB / NetBIOS', icon: Icons.folder),
       CategoryTile(title: 'UPnP', icon: Icons.cast),
       CategoryTile(title: 'ARP Spoof', icon: Icons.security),
+      CategoryTile(title: 'DHCP', icon: Icons.wifi),
     ];
   }
 
@@ -174,6 +175,26 @@ class _StaticScanTabState extends State<StaticScanTab> {
               : (arpVuln ? ScanStatus.warning : ScanStatus.ok)
           ..details = [
             if (arpExplain != null) arpExplain else '情報取得失敗',
+          ];
+
+        final dhcpFinding = findings.firstWhere(
+          (f) => f['category'] == 'dhcp',
+          orElse: () => <String, dynamic>{},
+        );
+        final dhcpDetails =
+            (dhcpFinding['details'] as Map?)?.cast<String, dynamic>() ?? {};
+        final dhcpServers =
+            (dhcpDetails['servers'] as List? ?? []).cast<String>();
+        final dhcpWarnings =
+            (dhcpDetails['warnings'] as List? ?? []).cast<String>();
+        _categories[5]
+          ..status = dhcpWarnings.isNotEmpty
+              ? ScanStatus.warning
+              : (dhcpServers.isEmpty ? ScanStatus.error : ScanStatus.ok)
+          ..details = [
+            ...dhcpWarnings,
+            ...dhcpServers.map((ip) => 'サーバー $ip'),
+            if (dhcpWarnings.isEmpty && dhcpServers.isEmpty) '応答なし',
           ];
       });
     });

--- a/nw_checker/test/static_scan_tab_flow_test.dart
+++ b/nw_checker/test/static_scan_tab_flow_test.dart
@@ -42,6 +42,13 @@ void main() {
             'explanation': 'ARP table updated with spoofed entry',
           },
         },
+        {
+          'category': 'dhcp',
+          'details': {
+            'servers': ['10.0.0.1'],
+            'warnings': []
+          },
+        },
       ],
     };
   }
@@ -56,9 +63,10 @@ void main() {
 
     // Initial summary and status badges
     expect(find.text('スキャン未実施'), findsOneWidget);
-    expect(find.byType(ListView), findsOneWidget);
+    final listFinder = find.byType(Scrollable);
+    expect(listFinder, findsOneWidget);
     final initialChips = tester.widgetList<Chip>(find.byType(Chip)).toList();
-    expect(initialChips, hasLength(5));
+    expect(initialChips, hasLength(6));
     expect(initialChips.every((c) => c.backgroundColor == Colors.grey), isTrue);
 
     await tester.tap(find.byKey(const Key('staticButton')));
@@ -77,10 +85,12 @@ void main() {
     final smbDy = tester.getTopLeft(find.text('SMB / NetBIOS')).dy;
     final upnpDy = tester.getTopLeft(find.text('UPnP')).dy;
     final arpDy = tester.getTopLeft(find.text('ARP Spoof')).dy;
+    final dhcpDy = tester.getTopLeft(find.text('DHCP')).dy;
     expect(portDy < osDy, isTrue);
     expect(osDy < smbDy, isTrue);
     expect(smbDy < upnpDy, isTrue);
     expect(upnpDy < arpDy, isTrue);
+    expect(arpDy < dhcpDy, isTrue);
 
     // ステータスバッジと色
     final chipsAfter = tester.widgetList<Chip>(find.byType(Chip)).toList();
@@ -89,6 +99,7 @@ void main() {
     final thirdLabel = chipsAfter[2].label as Text;
     final fourthLabel = chipsAfter[3].label as Text;
     final fifthLabel = chipsAfter[4].label as Text;
+    final sixthLabel = chipsAfter[5].label as Text;
     expect(firstLabel.data, '警告');
     expect(chipsAfter[0].backgroundColor, Colors.orange);
     expect(secondLabel.data, 'OK');
@@ -99,6 +110,8 @@ void main() {
     expect(chipsAfter[3].backgroundColor, Colors.orange);
     expect(fifthLabel.data, '警告');
     expect(chipsAfter[4].backgroundColor, Colors.orange);
+    expect(sixthLabel.data, 'OK');
+    expect(chipsAfter[5].backgroundColor, Colors.blueGrey);
 
     // 警告ラベルが3つあること
     expect(find.text('警告'), findsNWidgets(3));
@@ -120,15 +133,26 @@ void main() {
     expect(find.text('SMBv1: 無効'), findsOneWidget);
     expect(find.text('NetBIOS: HOST'), findsOneWidget);
 
+    await tester.scrollUntilVisible(find.text('UPnP'), 500, scrollable: listFinder);
     await tester.tap(find.text('UPnP'));
     await tester.pumpAndSettle();
     expect(find.text('UPnP service responded from 1.1.1.1'), findsOneWidget);
+    await tester.tap(find.text('UPnP'));
+    await tester.pumpAndSettle();
 
+    await tester.scrollUntilVisible(find.text('ARP Spoof'), 500, scrollable: listFinder);
     await tester.tap(find.text('ARP Spoof'));
     await tester.pumpAndSettle();
     expect(
       find.text('ARP table updated with spoofed entry'),
       findsOneWidget,
     );
+    await tester.tap(find.text('ARP Spoof'));
+    await tester.pumpAndSettle();
+
+    await tester.scrollUntilVisible(find.text('DHCP'), 500, scrollable: listFinder);
+    await tester.tap(find.text('DHCP'));
+    await tester.pumpAndSettle();
+    expect(find.text('サーバー 10.0.0.1'), findsOneWidget);
   });
 }

--- a/nw_checker/test/static_scan_tab_test.dart
+++ b/nw_checker/test/static_scan_tab_test.dart
@@ -37,6 +37,13 @@ void main() {
               'explanation': 'No ARP poisoning detected',
             },
           },
+          {
+            'category': 'dhcp',
+            'details': {
+              'servers': ['10.0.0.1'],
+              'warnings': []
+            },
+          },
         ],
       };
     }
@@ -49,7 +56,7 @@ void main() {
     await tester.pump();
     await tester.pumpAndSettle();
 
-    expect(find.text('OK'), findsNWidgets(5));
+    expect(find.text('OK'), findsNWidgets(6));
     expect(find.text('警告'), findsNothing);
   });
 
@@ -79,6 +86,13 @@ void main() {
             'details': {
               'vulnerable': false,
               'explanation': 'No ARP poisoning detected',
+            },
+          },
+          {
+            'category': 'dhcp',
+            'details': {
+              'servers': ['10.0.0.1'],
+              'warnings': []
             },
           },
         ],
@@ -131,6 +145,13 @@ void main() {
               'explanation': 'No ARP poisoning detected',
             },
           },
+          {
+            'category': 'dhcp',
+            'details': {
+              'servers': ['10.0.0.1'],
+              'warnings': []
+            },
+          },
         ],
       };
     }
@@ -179,6 +200,13 @@ void main() {
               'explanation': 'No ARP poisoning detected',
             },
           },
+          {
+            'category': 'dhcp',
+            'details': {
+              'servers': ['10.0.0.1'],
+              'warnings': []
+            },
+          },
         ],
       };
     }
@@ -225,6 +253,20 @@ void main() {
               'warnings': ['Misconfigured SSDP response from 1.1.1.1'],
             },
           },
+          {
+            'category': 'arp_spoof',
+            'details': {
+              'vulnerable': false,
+              'explanation': 'No ARP poisoning detected',
+            },
+          },
+          {
+            'category': 'dhcp',
+            'details': {
+              'servers': ['10.0.0.1'],
+              'warnings': []
+            },
+          },
         ],
       };
     }
@@ -244,6 +286,64 @@ void main() {
     await tester.pumpAndSettle();
     expect(
       find.text('Misconfigured SSDP response from 1.1.1.1'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('multiple DHCP servers show warning in tile', (tester) async {
+    Future<Map<String, dynamic>> mockScan() async {
+      return {
+        'summary': [],
+        'findings': [
+          {
+            'category': 'ports',
+            'details': {'open_ports': []},
+          },
+          {
+            'category': 'os_banner',
+            'details': {'os': 'Linux', 'banners': {}},
+          },
+          {
+            'category': 'smb_netbios',
+            'details': {'smb1_enabled': false, 'netbios_names': []},
+          },
+          {
+            'category': 'upnp',
+            'details': {'responders': [], 'warnings': []},
+          },
+          {
+            'category': 'arp_spoof',
+            'details': {
+              'vulnerable': false,
+              'explanation': 'No ARP poisoning detected',
+            },
+          },
+          {
+            'category': 'dhcp',
+            'details': {
+              'servers': ['1.1.1.1', '2.2.2.2'],
+              'warnings': ['Multiple DHCP servers detected: 1.1.1.1, 2.2.2.2'],
+            },
+          },
+        ],
+      };
+    }
+
+    await tester.pumpWidget(
+      MaterialApp(home: StaticScanTab(scanner: mockScan)),
+    );
+
+    await tester.tap(find.byKey(const Key('staticButton')));
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    final chips = tester.widgetList<Chip>(find.byType(Chip)).toList();
+    final dhcpLabel = chips[5].label as Text;
+    expect(dhcpLabel.data, '警告');
+    await tester.tap(find.text('DHCP'));
+    await tester.pumpAndSettle();
+    expect(
+      find.text('Multiple DHCP servers detected: 1.1.1.1, 2.2.2.2'),
       findsOneWidget,
     );
   });

--- a/src/scans/dhcp.py
+++ b/src/scans/dhcp.py
@@ -1,11 +1,11 @@
 """Static scan for rogue DHCP servers using scapy."""
 
 from scapy.all import (  # type: ignore
+    BOOTP,
+    DHCP,
     Ether,
     IP,
     UDP,
-    BOOTP,
-    DHCP,
     srp,
 )
 
@@ -14,6 +14,7 @@ def scan(timeout: int = 2) -> dict:
     """Broadcast a DHCP discover and return responding servers."""
 
     servers = []
+    warnings = []
     try:
         discover = (
             Ether(dst="ff:ff:ff:ff:ff:ff")
@@ -29,9 +30,12 @@ def scan(timeout: int = 2) -> dict:
     except Exception:  # pragma: no cover
         pass
 
+    if len(servers) > 1:
+        warnings.append("Multiple DHCP servers detected: " + ", ".join(servers))
+
     return {
         "category": "dhcp",
         "score": len(servers),
-        "details": {"servers": servers},
+        "details": {"servers": servers, "warnings": warnings},
     }
 


### PR DESCRIPTION
## Summary
- implement DHCP discover scan with server IP tracking and conflict warnings
- expose DHCP results on new static scan tile
- cover DHCP detection and UI behavior with tests

## Testing
- `pytest`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_6899a7dfbf5c8323bffed6891f3c6fd9