### PR TITLE
feat: add configurable traffic anomaly detection

### DIFF
--- a/src/dynamic_scan/config.json
+++ b/src/dynamic_scan/config.json
@@ -1,0 +1,3 @@
+{
+  "traffic_threshold": 1000000
+}

--- a/tests/test_dynamic_scan_analyze.py
+++ b/tests/test_dynamic_scan_analyze.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 from datetime import datetime
+import json
 import types
 
 import pytest
@@ -85,6 +86,15 @@ def test_detect_traffic_anomaly():
     stats = defaultdict(int)
     assert analyze.detect_traffic_anomaly(stats, "host", 500_000, threshold=1_000_000) is False
     assert analyze.detect_traffic_anomaly(stats, "host", 600_000, threshold=1_000_000) is True
+
+
+def test_detect_traffic_anomaly_from_config(tmp_path, monkeypatch):
+    stats = defaultdict(int)
+    cfg = tmp_path / "config.json"
+    cfg.write_text(json.dumps({"traffic_threshold": 700_000}))
+    monkeypatch.setattr(analyze, "CONFIG_PATH", cfg)
+    assert analyze.detect_traffic_anomaly(stats, "host", 400_000) is False
+    assert analyze.detect_traffic_anomaly(stats, "host", 400_000) is True
 
 
 def test_is_night_traffic():


### PR DESCRIPTION
## Summary
- load traffic anomaly threshold from config file with argument override
- aggregate packet sizes in traffic_stats to detect anomalies
- cover configurable threshold behavior with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899a7e980bc832386f9bf1a6545f99c