### PR TITLE
Load DNS blacklist from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # nw-checker
+
+## DNS Blacklist
+
+The dynamic scan compares reverse DNS results against a configurable
+blacklist. Edit `data/dns_blacklist.txt` to add or remove domains. Each
+non-empty line should contain a single domain name; lines beginning with
+`#` are treated as comments.
+

--- a/data/dns_blacklist.txt
+++ b/data/dns_blacklist.txt
@@ -1,0 +1,2 @@
+# Default DNS blacklist
+malicious.example

--- a/nw_checker/test/static_scan_tab_test.dart
+++ b/nw_checker/test/static_scan_tab_test.dart
@@ -199,8 +199,7 @@ void main() {
     expect(find.text('UPnP service responded from 1.1.1.1'), findsOneWidget);
   });
 
-  testWidgets('ARP spoof detection shows warning in tile', (tester) async {
-  testWidgets('misconfigured UPnP response shows warning in tile', (tester,) async {
+  testWidgets('misconfigured UPnP response shows warning in tile', (tester) async {
     Future<Map<String, dynamic>> mockScan() async {
       return {
         'summary': [],
@@ -260,8 +259,6 @@ void main() {
     expect(
       find.text('ARP table updated with spoofed entry'),
       findsOneWidget,
-    );
-
     );
   });
 }

--- a/src/dynamic_scan/analyze.py
+++ b/src/dynamic_scan/analyze.py
@@ -11,8 +11,22 @@ import requests
 
 # 危険とされるプロトコルの名称
 DANGEROUS_PROTOCOLS = {"telnet", "ftp", "rdp"}
+
+
+def load_blacklist(path: str = "data/dns_blacklist.txt") -> set[str]:
+    try:
+        with open(path) as f:
+            return {
+                line.strip()
+                for line in f
+                if line.strip() and not line.startswith("#")
+            }
+    except FileNotFoundError:
+        return set()
+
+
 # DNS 逆引きのブラックリスト
-DNS_BLACKLIST = {"malicious.example"}
+DNS_BLACKLIST = load_blacklist()
 
 CONFIG_PATH = Path(__file__).with_name("config.json")
 

--- a/tests/test_dynamic_scan_analyze.py
+++ b/tests/test_dynamic_scan_analyze.py
@@ -109,6 +109,22 @@ def test_load_threshold_default_when_missing(tmp_path, monkeypatch):
     assert analyze.load_threshold(default=654_321) == 654_321
 
 
+def test_load_blacklist(tmp_path):
+    blk = tmp_path / "dns_blacklist.txt"
+    blk.write_text("# comment\nfoo.example\n\nbar.example\n")
+    result = analyze.load_blacklist(blk)
+    assert result == {"foo.example", "bar.example"}
+
+
+def test_load_blacklist_missing_file(tmp_path):
+    missing = tmp_path / "no_such_file.txt"
+    assert analyze.load_blacklist(missing) == set()
+
+
+def test_load_blacklist_default_file():
+    assert "malicious.example" in analyze.load_blacklist()
+
+
 def test_is_night_traffic():
     night_ts = datetime(2024, 1, 1, 3, 0).timestamp()
     day_ts = datetime(2024, 1, 1, 7, 0).timestamp()


### PR DESCRIPTION
## Summary
- load DNS blacklist from `data/dns_blacklist.txt`
- document DNS blacklist location for operators
- handle missing blacklist file gracefully and add unit tests for the loader

## Testing
- `pytest`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_689b027710bc8323871e5b3250590f3a