### PR TITLE
feat: add out-of-hours detection

### DIFF
--- a/tests/test_dynamic_scan_analyze.py
+++ b/tests/test_dynamic_scan_analyze.py
@@ -184,7 +184,7 @@ def test_detect_out_of_hours():
     pkt = type(
         "Pkt", (), {"timestamp": datetime(2024, 1, 1, 3, 0).timestamp()}
     )
-    res = analyze.detect_out_of_hours(pkt, (9, 17))
+    res = analyze.detect_out_of_hours(pkt, 9, 17)
     assert res.out_of_hours is True
 
 def test_record_dns_history_no_hostname(monkeypatch):
@@ -253,8 +253,24 @@ def test_detect_out_of_hours_within_schedule():
     pkt = type(
         "Pkt", (), {"timestamp": datetime(2024, 1, 1, 10, 0).timestamp()}
     )
-    res = analyze.detect_out_of_hours(pkt, (9, 17))
+    res = analyze.detect_out_of_hours(pkt, 9, 17)
     assert res.out_of_hours is False
+
+
+def test_detect_out_of_hours_at_start_hour():
+    pkt = type(
+        "Pkt", (), {"timestamp": datetime(2024, 1, 1, 9, 0).timestamp()}
+    )
+    res = analyze.detect_out_of_hours(pkt, 9, 17)
+    assert res.out_of_hours is False
+
+
+def test_detect_out_of_hours_at_end_hour():
+    pkt = type(
+        "Pkt", (), {"timestamp": datetime(2024, 1, 1, 17, 0).timestamp()}
+    )
+    res = analyze.detect_out_of_hours(pkt, 9, 17)
+    assert res.out_of_hours is True
 
 
 def test_analysis_result_merge_and_to_dict():


### PR DESCRIPTION
## Summary
- allow specifying start and end hours when detecting off-hours traffic
- record out-of-hours flag in AnalysisResult
- cover out-of-hours cases with tests
- add boundary and pipeline tests for out-of-hours detection

## Testing
- `pytest tests/test_dynamic_scan_analyze.py tests/test_dynamic_scan.py`

------
https://chatgpt.com/codex/tasks/task_e_689b027e10b08323b1155e559010266b