### PR TITLE
Add DHCP scan with conflict detection and UI tile

### DIFF
--- a/nw_checker/lib/static_scan_tab.dart
+++ b/nw_checker/lib/static_scan_tab.dart
@@ -64,6 +64,7 @@ class _StaticScanTabState extends State<StaticScanTab> {
       CategoryTile(title: 'SMB / NetBIOS', icon: Icons.folder),
       CategoryTile(title: 'UPnP', icon: Icons.cast),
       CategoryTile(title: 'ARP Spoof', icon: Icons.security),
+      CategoryTile(title: 'DHCP', icon: Icons.dns),
     ];
   }
 
@@ -174,6 +175,26 @@ class _StaticScanTabState extends State<StaticScanTab> {
               : (arpVuln ? ScanStatus.warning : ScanStatus.ok)
           ..details = [
             if (arpExplain != null) arpExplain else '情報取得失敗',
+          ];
+
+        final dhcpFinding = findings.firstWhere(
+          (f) => f['category'] == 'dhcp',
+          orElse: () => <String, dynamic>{},
+        );
+        final dhcpDetails =
+            (dhcpFinding['details'] as Map?)?.cast<String, dynamic>() ?? {};
+        final dhcpServers =
+            (dhcpDetails['servers'] as List? ?? []).cast<String>();
+        final dhcpWarnings =
+            (dhcpDetails['warnings'] as List? ?? []).cast<String>();
+        _categories[5]
+          ..status = dhcpServers.isEmpty
+              ? ScanStatus.error
+              : (dhcpWarnings.isEmpty ? ScanStatus.ok : ScanStatus.warning)
+          ..details = [
+            ...dhcpWarnings,
+            ...dhcpServers.map((ip) => 'サーバー $ip'),
+            if (dhcpServers.isEmpty) '応答なし',
           ];
       });
     });

--- a/nw_checker/test/static_scan_tab_flow_test.dart
+++ b/nw_checker/test/static_scan_tab_flow_test.dart
@@ -42,6 +42,13 @@ void main() {
             'explanation': 'ARP table updated with spoofed entry',
           },
         },
+        {
+          'category': 'dhcp',
+          'details': {
+            'servers': ['1.1.1.1'],
+            'warnings': [],
+          },
+        },
       ],
     };
   }
@@ -58,7 +65,7 @@ void main() {
     expect(find.text('スキャン未実施'), findsOneWidget);
     expect(find.byType(ListView), findsOneWidget);
     final initialChips = tester.widgetList<Chip>(find.byType(Chip)).toList();
-    expect(initialChips, hasLength(5));
+    expect(initialChips, hasLength(6));
     expect(initialChips.every((c) => c.backgroundColor == Colors.grey), isTrue);
 
     await tester.tap(find.byKey(const Key('staticButton')));
@@ -77,10 +84,12 @@ void main() {
     final smbDy = tester.getTopLeft(find.text('SMB / NetBIOS')).dy;
     final upnpDy = tester.getTopLeft(find.text('UPnP')).dy;
     final arpDy = tester.getTopLeft(find.text('ARP Spoof')).dy;
+    final dhcpDy = tester.getTopLeft(find.text('DHCP')).dy;
     expect(portDy < osDy, isTrue);
     expect(osDy < smbDy, isTrue);
     expect(smbDy < upnpDy, isTrue);
     expect(upnpDy < arpDy, isTrue);
+    expect(arpDy < dhcpDy, isTrue);
 
     // ステータスバッジと色
     final chipsAfter = tester.widgetList<Chip>(find.byType(Chip)).toList();
@@ -89,6 +98,7 @@ void main() {
     final thirdLabel = chipsAfter[2].label as Text;
     final fourthLabel = chipsAfter[3].label as Text;
     final fifthLabel = chipsAfter[4].label as Text;
+    final sixthLabel = chipsAfter[5].label as Text;
     expect(firstLabel.data, '警告');
     expect(chipsAfter[0].backgroundColor, Colors.orange);
     expect(secondLabel.data, 'OK');
@@ -99,6 +109,8 @@ void main() {
     expect(chipsAfter[3].backgroundColor, Colors.orange);
     expect(fifthLabel.data, '警告');
     expect(chipsAfter[4].backgroundColor, Colors.orange);
+    expect(sixthLabel.data, 'OK');
+    expect(chipsAfter[5].backgroundColor, Colors.blueGrey);
 
     // 警告ラベルが3つあること
     expect(find.text('警告'), findsNWidgets(3));

--- a/nw_checker/test/static_scan_tab_test.dart
+++ b/nw_checker/test/static_scan_tab_test.dart
@@ -14,10 +14,7 @@ void main() {
       return {
         'summary': [],
         'findings': [
-          {
-            'category': 'ports',
-            'details': {'open_ports': []},
-          },
+          {'category': 'ports', 'details': {'open_ports': []}},
           {
             'category': 'os_banner',
             'details': {'os': 'Linux', 'banners': {}},
@@ -37,6 +34,13 @@ void main() {
               'explanation': 'No ARP poisoning detected',
             },
           },
+          {
+            'category': 'dhcp',
+            'details': {
+              'servers': ['1.1.1.1'],
+              'warnings': [],
+            },
+          },
         ],
       };
     }
@@ -49,7 +53,7 @@ void main() {
     await tester.pump();
     await tester.pumpAndSettle();
 
-    expect(find.text('OK'), findsNWidgets(5));
+    expect(find.text('OK'), findsNWidgets(6));
     expect(find.text('警告'), findsNothing);
   });
 
@@ -58,14 +62,8 @@ void main() {
       return {
         'summary': [],
         'findings': [
-          {
-            'category': 'ports',
-            'details': {'open_ports': []},
-          },
-          {
-            'category': 'os_banner',
-            'details': {'os': '', 'banners': {}},
-          },
+          {'category': 'ports', 'details': {'open_ports': []}},
+          {'category': 'os_banner', 'details': {'os': '', 'banners': {}}},
           {
             'category': 'smb_netbios',
             'details': {'smb1_enabled': false, 'netbios_names': []},
@@ -79,6 +77,13 @@ void main() {
             'details': {
               'vulnerable': false,
               'explanation': 'No ARP poisoning detected',
+            },
+          },
+          {
+            'category': 'dhcp',
+            'details': {
+              'servers': ['1.1.1.1'],
+              'warnings': [],
             },
           },
         ],
@@ -108,10 +113,7 @@ void main() {
       return {
         'summary': [],
         'findings': [
-          {
-            'category': 'ports',
-            'details': {'open_ports': []},
-          },
+          {'category': 'ports', 'details': {'open_ports': []}},
           {
             'category': 'os_banner',
             'details': {'os': 'Linux', 'banners': {}},
@@ -129,6 +131,13 @@ void main() {
             'details': {
               'vulnerable': false,
               'explanation': 'No ARP poisoning detected',
+            },
+          },
+          {
+            'category': 'dhcp',
+            'details': {
+              'servers': ['1.1.1.1'],
+              'warnings': [],
             },
           },
         ],
@@ -153,10 +162,7 @@ void main() {
       return {
         'summary': [],
         'findings': [
-          {
-            'category': 'ports',
-            'details': {'open_ports': []},
-          },
+          {'category': 'ports', 'details': {'open_ports': []}},
           {
             'category': 'os_banner',
             'details': {'os': 'Linux', 'banners': {}},
@@ -177,6 +183,13 @@ void main() {
             'details': {
               'vulnerable': false,
               'explanation': 'No ARP poisoning detected',
+            },
+          },
+          {
+            'category': 'dhcp',
+            'details': {
+              'servers': ['1.1.1.1'],
+              'warnings': [],
             },
           },
         ],
@@ -204,10 +217,7 @@ void main() {
       return {
         'summary': [],
         'findings': [
-          {
-            'category': 'ports',
-            'details': {'open_ports': []},
-          },
+          {'category': 'ports', 'details': {'open_ports': []}},
           {
             'category': 'os_banner',
             'details': {'os': 'Linux', 'banners': {}},
@@ -228,6 +238,13 @@ void main() {
             'details': {
               'vulnerable': true,
               'explanation': 'ARP table updated with spoofed entry',
+            },
+          },
+          {
+            'category': 'dhcp',
+            'details': {
+              'servers': ['1.1.1.1'],
+              'warnings': [],
             },
           },
         ],
@@ -261,4 +278,62 @@ void main() {
       findsOneWidget,
     );
   });
+
+  testWidgets('multiple DHCP servers show warning in tile', (tester) async {
+    Future<Map<String, dynamic>> mockScan() async {
+      return {
+        'summary': [],
+        'findings': [
+          {'category': 'ports', 'details': {'open_ports': []}},
+          {
+            'category': 'os_banner',
+            'details': {'os': 'Linux', 'banners': {}},
+          },
+          {
+            'category': 'smb_netbios',
+            'details': {'smb1_enabled': false, 'netbios_names': []},
+          },
+          {
+            'category': 'upnp',
+            'details': {'responders': [], 'warnings': []},
+          },
+          {
+            'category': 'arp_spoof',
+            'details': {
+              'vulnerable': false,
+              'explanation': 'No ARP poisoning detected',
+            },
+          },
+          {
+            'category': 'dhcp',
+            'details': {
+              'servers': ['1.1.1.1', '2.2.2.2'],
+              'warnings': [
+                'Multiple DHCP servers detected: 1.1.1.1, 2.2.2.2'
+              ],
+            },
+          },
+        ],
+      };
+    }
+
+    await tester.pumpWidget(
+      MaterialApp(home: StaticScanTab(scanner: mockScan)),
+    );
+
+    await tester.tap(find.byKey(const Key('staticButton')));
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    final chips = tester.widgetList<Chip>(find.byType(Chip)).toList();
+    final dhcpLabel = chips[5].label as Text;
+    expect(dhcpLabel.data, '警告');
+    await tester.tap(find.text('DHCP'));
+    await tester.pumpAndSettle();
+    expect(
+      find.text('Multiple DHCP servers detected: 1.1.1.1, 2.2.2.2'),
+      findsOneWidget,
+    );
+  });
 }
+

--- a/src/scans/dhcp.py
+++ b/src/scans/dhcp.py
@@ -11,9 +11,14 @@ from scapy.all import (  # type: ignore
 
 
 def scan(timeout: int = 2) -> dict:
-    """Broadcast a DHCP discover and return responding servers."""
+    """Broadcast a DHCP discover and return responding servers.
+
+    Returns a mapping with the list of responding server IPs and warnings
+    if multiple servers answer which can indicate configuration conflicts.
+    """
 
     servers = []
+    warnings = []
     try:
         discover = (
             Ether(dst="ff:ff:ff:ff:ff:ff")
@@ -26,12 +31,17 @@ def scan(timeout: int = 2) -> dict:
         for _, pkt in ans:
             if DHCP in pkt:
                 servers.append(pkt[IP].src)
-    except Exception:  # pragma: no cover
+    except Exception:  # pragma: no cover - 実行環境による
         pass
+
+    if len(servers) > 1:
+        warnings.append(
+            "Multiple DHCP servers detected: " + ", ".join(sorted(servers))
+        )
 
     return {
         "category": "dhcp",
         "score": len(servers),
-        "details": {"servers": servers},
+        "details": {"servers": servers, "warnings": warnings},
     }
 


### PR DESCRIPTION
## Summary
- extend DHCP scan to warn when multiple servers respond
- surface DHCP server details and conflicts on new Static Scan tab tile
- add tests for DHCP scan and UI behaviour

## Testing
- `pytest`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_689b07377d2c832385991c7601adb979