### PR TITLE
Add nmblookup fallback for SMB scan

### DIFF
--- a/src/scans/smb_netbios.py
+++ b/src/scans/smb_netbios.py
@@ -6,8 +6,35 @@ determine whether SMBv1 is enabled on the target host.
 
 from __future__ import annotations
 
+import subprocess
+
 from impacket.nmb import NetBIOS
 from impacket.smbconnection import SMBConnection
+
+
+def _nmblookup_names(target: str) -> list[str]:
+    """Resolve NetBIOS names via ``nmblookup``.
+
+    ``impacket`` が利用できない環境でも NetBIOS 名を取得できるようにする。
+    失敗時は空リストを返す。
+    """
+
+    try:
+        output = subprocess.check_output(
+            ["nmblookup", "-A", target], text=True, timeout=3
+        )
+    except Exception:  # pragma: no cover - 実行環境による失敗は無視
+        return []
+
+    names: list[str] = []
+    for line in output.splitlines():
+        line = line.strip()
+        if not line or line.startswith("Looking up") or "MAC Address" in line:
+            continue
+        name = line.split("<", 1)[0].strip()
+        if name:
+            names.append(name)
+    return names
 
 
 def scan(target: str = "127.0.0.1") -> dict:
@@ -21,16 +48,21 @@ def scan(target: str = "127.0.0.1") -> dict:
     smb1_enabled = False
 
     # --- NetBIOS name lookup -------------------------------------------------
+    names: list[str] = []
     try:
         nb = NetBIOS()
         try:
-            names = nb.queryIPForName(target, timeout=2)
-            if names:
-                details["netbios_names"] = names
+            names = nb.queryIPForName(target, timeout=2) or []
         finally:
             nb.close()
     except Exception:  # pragma: no cover - ネットワークエラー等は無視
         pass
+
+    if not names:
+        names = _nmblookup_names(target)
+
+    if names:
+        details["netbios_names"] = names
 
     # --- SMB dialect negotiation --------------------------------------------
     try:


### PR DESCRIPTION
## Summary
- add `nmblookup` fallback in SMB/NetBIOS scan to collect names when impacket fails
- cover nmblookup path with tests and ensure SMB scan details are aggregated

## Testing
- `pytest`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_689b2b5532308323bfc7ede34665f199