### PR TITLE
Add SSL certificate results to static scan UI

### DIFF
--- a/nw_checker/test/static_scan_tab_flow_test.dart
+++ b/nw_checker/test/static_scan_tab_flow_test.dart
@@ -49,12 +49,17 @@ void main() {
             'warnings': [],
           },
         },
+        {
+          'category': 'ssl_cert',
+          'details': {'host': 'example.com', 'expired': false},
+        },
       ],
     };
   }
 
-  Widget buildWidget() =>
-      MaterialApp(home: Scaffold(body: StaticScanTab(scanner: mockScan)));
+  Widget buildWidget() => MaterialApp(
+    home: Scaffold(body: StaticScanTab(scanner: mockScan)),
+  );
 
   testWidgets('button tap shows progress then results and categories', (
     tester,
@@ -65,7 +70,7 @@ void main() {
     expect(find.text('スキャン未実施'), findsOneWidget);
     expect(find.byType(ListView), findsOneWidget);
     final initialChips = tester.widgetList<Chip>(find.byType(Chip)).toList();
-    expect(initialChips, hasLength(6));
+    expect(initialChips, hasLength(7));
     expect(initialChips.every((c) => c.backgroundColor == Colors.grey), isTrue);
 
     await tester.tap(find.byKey(const Key('staticButton')));
@@ -85,11 +90,13 @@ void main() {
     final upnpDy = tester.getTopLeft(find.text('UPnP')).dy;
     final arpDy = tester.getTopLeft(find.text('ARP Spoof')).dy;
     final dhcpDy = tester.getTopLeft(find.text('DHCP')).dy;
+    final sslDy = tester.getTopLeft(find.text('SSL証明書')).dy;
     expect(portDy < osDy, isTrue);
     expect(osDy < smbDy, isTrue);
     expect(smbDy < upnpDy, isTrue);
     expect(upnpDy < arpDy, isTrue);
     expect(arpDy < dhcpDy, isTrue);
+    expect(dhcpDy < sslDy, isTrue);
 
     // ステータスバッジと色
     final chipsAfter = tester.widgetList<Chip>(find.byType(Chip)).toList();
@@ -99,6 +106,7 @@ void main() {
     final fourthLabel = chipsAfter[3].label as Text;
     final fifthLabel = chipsAfter[4].label as Text;
     final sixthLabel = chipsAfter[5].label as Text;
+    final seventhLabel = chipsAfter[6].label as Text;
     expect(firstLabel.data, '警告');
     expect(chipsAfter[0].backgroundColor, Colors.orange);
     expect(secondLabel.data, 'OK');
@@ -111,6 +119,8 @@ void main() {
     expect(chipsAfter[4].backgroundColor, Colors.orange);
     expect(sixthLabel.data, 'OK');
     expect(chipsAfter[5].backgroundColor, Colors.blueGrey);
+    expect(seventhLabel.data, 'OK');
+    expect(chipsAfter[6].backgroundColor, Colors.blueGrey);
 
     // 警告ラベルが3つあること
     expect(find.text('警告'), findsNWidgets(3));
@@ -142,9 +152,6 @@ void main() {
     await tester.pumpAndSettle();
     await tester.tap(find.text('ARP Spoof'));
     await tester.pumpAndSettle();
-    expect(
-      find.text('ARP table updated with spoofed entry'),
-      findsOneWidget,
-    );
+    expect(find.text('ARP table updated with spoofed entry'), findsOneWidget);
   });
 }

--- a/nw_checker/test/static_scan_tab_test.dart
+++ b/nw_checker/test/static_scan_tab_test.dart
@@ -14,7 +14,10 @@ void main() {
       return {
         'summary': [],
         'findings': [
-          {'category': 'ports', 'details': {'open_ports': []}},
+          {
+            'category': 'ports',
+            'details': {'open_ports': []},
+          },
           {
             'category': 'os_banner',
             'details': {'os': 'Linux', 'banners': {}},
@@ -41,6 +44,10 @@ void main() {
               'warnings': [],
             },
           },
+          {
+            'category': 'ssl_cert',
+            'details': {'host': 'example.com', 'expired': false},
+          },
         ],
       };
     }
@@ -53,7 +60,7 @@ void main() {
     await tester.pump();
     await tester.pumpAndSettle();
 
-    expect(find.text('OK'), findsNWidgets(6));
+    expect(find.text('OK'), findsNWidgets(7));
     expect(find.text('警告'), findsNothing);
   });
 
@@ -62,8 +69,14 @@ void main() {
       return {
         'summary': [],
         'findings': [
-          {'category': 'ports', 'details': {'open_ports': []}},
-          {'category': 'os_banner', 'details': {'os': '', 'banners': {}}},
+          {
+            'category': 'ports',
+            'details': {'open_ports': []},
+          },
+          {
+            'category': 'os_banner',
+            'details': {'os': '', 'banners': {}},
+          },
           {
             'category': 'smb_netbios',
             'details': {'smb1_enabled': false, 'netbios_names': []},
@@ -85,6 +98,10 @@ void main() {
               'servers': ['1.1.1.1'],
               'warnings': [],
             },
+          },
+          {
+            'category': 'ssl_cert',
+            'details': {'host': 'example.com', 'expired': false},
           },
         ],
       };
@@ -113,7 +130,10 @@ void main() {
       return {
         'summary': [],
         'findings': [
-          {'category': 'ports', 'details': {'open_ports': []}},
+          {
+            'category': 'ports',
+            'details': {'open_ports': []},
+          },
           {
             'category': 'os_banner',
             'details': {'os': 'Linux', 'banners': {}},
@@ -140,6 +160,10 @@ void main() {
               'warnings': [],
             },
           },
+          {
+            'category': 'ssl_cert',
+            'details': {'host': 'example.com', 'expired': false},
+          },
         ],
       };
     }
@@ -162,7 +186,10 @@ void main() {
       return {
         'summary': [],
         'findings': [
-          {'category': 'ports', 'details': {'open_ports': []}},
+          {
+            'category': 'ports',
+            'details': {'open_ports': []},
+          },
           {
             'category': 'os_banner',
             'details': {'os': 'Linux', 'banners': {}},
@@ -192,6 +219,10 @@ void main() {
               'warnings': [],
             },
           },
+          {
+            'category': 'ssl_cert',
+            'details': {'host': 'example.com', 'expired': false},
+          },
         ],
       };
     }
@@ -212,12 +243,17 @@ void main() {
     expect(find.text('UPnP service responded from 1.1.1.1'), findsOneWidget);
   });
 
-  testWidgets('misconfigured UPnP response shows warning in tile', (tester) async {
+  testWidgets('misconfigured UPnP response shows warning in tile', (
+    tester,
+  ) async {
     Future<Map<String, dynamic>> mockScan() async {
       return {
         'summary': [],
         'findings': [
-          {'category': 'ports', 'details': {'open_ports': []}},
+          {
+            'category': 'ports',
+            'details': {'open_ports': []},
+          },
           {
             'category': 'os_banner',
             'details': {'os': 'Linux', 'banners': {}},
@@ -247,6 +283,10 @@ void main() {
               'warnings': [],
             },
           },
+          {
+            'category': 'ssl_cert',
+            'details': {'host': 'example.com', 'expired': false},
+          },
         ],
       };
     }
@@ -273,10 +313,7 @@ void main() {
     expect(arpLabel.data, '警告');
     await tester.tap(find.text('ARP Spoof'));
     await tester.pumpAndSettle();
-    expect(
-      find.text('ARP table updated with spoofed entry'),
-      findsOneWidget,
-    );
+    expect(find.text('ARP table updated with spoofed entry'), findsOneWidget);
   });
 
   testWidgets('multiple DHCP servers show warning in tile', (tester) async {
@@ -284,7 +321,10 @@ void main() {
       return {
         'summary': [],
         'findings': [
-          {'category': 'ports', 'details': {'open_ports': []}},
+          {
+            'category': 'ports',
+            'details': {'open_ports': []},
+          },
           {
             'category': 'os_banner',
             'details': {'os': 'Linux', 'banners': {}},
@@ -308,10 +348,12 @@ void main() {
             'category': 'dhcp',
             'details': {
               'servers': ['1.1.1.1', '2.2.2.2'],
-              'warnings': [
-                'Multiple DHCP servers detected: 1.1.1.1, 2.2.2.2'
-              ],
+              'warnings': ['Multiple DHCP servers detected: 1.1.1.1, 2.2.2.2'],
             },
+          },
+          {
+            'category': 'ssl_cert',
+            'details': {'host': 'example.com', 'expired': false},
           },
         ],
       };
@@ -335,5 +377,63 @@ void main() {
       findsOneWidget,
     );
   });
-}
 
+  testWidgets('expired SSL certificate shows warning in tile', (tester) async {
+    Future<Map<String, dynamic>> mockScan() async {
+      return {
+        'summary': [],
+        'findings': [
+          {
+            'category': 'ports',
+            'details': {'open_ports': []},
+          },
+          {
+            'category': 'os_banner',
+            'details': {'os': 'Linux', 'banners': {}},
+          },
+          {
+            'category': 'smb_netbios',
+            'details': {'smb1_enabled': false, 'netbios_names': []},
+          },
+          {
+            'category': 'upnp',
+            'details': {'responders': [], 'warnings': []},
+          },
+          {
+            'category': 'arp_spoof',
+            'details': {
+              'vulnerable': false,
+              'explanation': 'No ARP poisoning detected',
+            },
+          },
+          {
+            'category': 'dhcp',
+            'details': {
+              'servers': ['1.1.1.1'],
+              'warnings': [],
+            },
+          },
+          {
+            'category': 'ssl_cert',
+            'details': {'host': 'example.com', 'expired': true},
+          },
+        ],
+      };
+    }
+
+    await tester.pumpWidget(
+      MaterialApp(home: StaticScanTab(scanner: mockScan)),
+    );
+
+    await tester.tap(find.byKey(const Key('staticButton')));
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    final chips = tester.widgetList<Chip>(find.byType(Chip)).toList();
+    final sslLabel = chips[6].label as Text;
+    expect(sslLabel.data, '警告');
+    await tester.tap(find.text('SSL証明書'));
+    await tester.pumpAndSettle();
+    expect(find.text('証明書は期限切れ'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- display new SSL certificate category with icon, status badge, and details in static scan tab
- style static scan start button in blue‑grey for subdued palette and keep warnings/errors in orange/red
- add widget tests for SSL certificate tile and update flow to cover new category

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'nmap')*
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_689b2b48db708323a7dec48a56ea3783