### PR TITLE
feat: allow custom ARP spoof parameters

### DIFF
--- a/src/scans/arp_spoof.py
+++ b/src/scans/arp_spoof.py
@@ -31,17 +31,31 @@ def _get_arp_table() -> Dict[str, str]:
     return table
 
 
-def scan(wait: float = 1.0) -> dict:
-    """Inject a spoofed ARP reply and watch for table changes."""
+def scan(
+    wait: float = 1.0,
+    fake_ip: str = FAKE_IP,
+    fake_mac: str = FAKE_MAC,
+) -> dict:
+    """Inject a spoofed ARP reply and watch for table changes.
+
+    Parameters
+    ----------
+    wait:
+        Packet送信後に待機する秒数。
+    fake_ip:
+        ARPテーブルに注入するIPアドレス。
+    fake_mac:
+        ``fake_ip`` に紐付ける偽のMACアドレス。
+    """
 
     before = _get_arp_table()
 
     try:
         pkt = ARP(
             op=2,  # is-at
-            psrc=FAKE_IP,
-            hwsrc=FAKE_MAC,
-            pdst=FAKE_IP,
+            psrc=fake_ip,
+            hwsrc=fake_mac,
+            pdst=fake_ip,
             hwdst="ff:ff:ff:ff:ff:ff",
         )
         send(pkt, verbose=False)
@@ -54,7 +68,7 @@ def scan(wait: float = 1.0) -> dict:
         }
 
     after = _get_arp_table()
-    changed = before.get(FAKE_IP) != FAKE_MAC and after.get(FAKE_IP) == FAKE_MAC
+    changed = before.get(fake_ip) != fake_mac and after.get(fake_ip) == fake_mac
     explanation = (
         "ARP table updated with spoofed entry"
         if changed

--- a/tests/test_scan_modules.py
+++ b/tests/test_scan_modules.py
@@ -321,6 +321,19 @@ def test_arp_spoof_scan_no_change(monkeypatch):
     )
 
 
+def test_arp_spoof_custom_ip_mac(monkeypatch):
+    """Custom IP/MACを指定しても検出できること。"""
+    tables = [
+        {"5.6.7.8": "aa:aa"},
+        {"5.6.7.8": "bb:bb"},
+    ]
+    monkeypatch.setattr(arp_spoof, "_get_arp_table", lambda: tables.pop(0))
+    monkeypatch.setattr(arp_spoof, "send", lambda *_, **__: None)
+    result = arp_spoof.scan(wait=0, fake_ip="5.6.7.8", fake_mac="bb:bb")
+    assert result["score"] == 5
+    assert result["details"]["vulnerable"] is True
+
+
 # --- SSL certificate -----------------------------------------------------
 
 def test_ssl_cert_scan_flags_expired(monkeypatch):


### PR DESCRIPTION
## Summary
- allow customizing IP and MAC for ARP spoof scan
- test ARP spoof scan with custom parameters

## Testing
- `pytest tests/test_scan_modules.py::test_arp_spoof_custom_ip_mac -q`
- `(cd nw_checker && flutter test)`

------
https://chatgpt.com/codex/tasks/task_e_689b2f134034832380b498742f04caea