### PR TITLE
feat: add UPnP SSDP scan

### DIFF
--- a/src/scans/upnp.py
+++ b/src/scans/upnp.py
@@ -2,22 +2,26 @@
 
 from scapy.all import IP, UDP, Raw, sr1  # type: ignore
 
+# SSDPのマルチキャストアドレスとポート
+SSDP_ADDR = "239.255.255.250"
+SSDP_PORT = 1900
 
-def scan(target: str = "239.255.255.250") -> dict:
-    """Send an SSDP M-SEARCH and evaluate responses."""
+
+def scan(target: str = SSDP_ADDR) -> dict:
+    """Send an SSDP M-SEARCH request and evaluate responses."""
 
     query = (
         "M-SEARCH * HTTP/1.1\r\n"
-        "HOST: 239.255.255.250:1900\r\n"
+        f"HOST: {SSDP_ADDR}:{SSDP_PORT}\r\n"
         'MAN: "ssdp:discover"\r\n'
         "MX: 1\r\n"
         "ST: ssdp:all\r\n\r\n"
     )
 
-    responders = []
-    warnings = []
+    responders: list[str] = []
+    warnings: list[str] = []
     try:
-        pkt = IP(dst=target) / UDP(sport=1900, dport=1900) / Raw(load=query)
+        pkt = IP(dst=target) / UDP(sport=SSDP_PORT, dport=SSDP_PORT) / Raw(load=query)
         ans = sr1(pkt, timeout=1, verbose=False)
         if ans:
             src = getattr(ans, "src", "")

--- a/tests/test_scan_modules.py
+++ b/tests/test_scan_modules.py
@@ -237,6 +237,19 @@ def test_upnp_scan_handles_no_response(monkeypatch):
     assert result["details"]["warnings"] == []
 
 
+def test_upnp_scan_handles_errors(monkeypatch):
+    """Exceptions from scapy should not crash the scan."""
+
+    def boom(*_, **__):  # noqa: D401, ARG002
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(upnp, "sr1", boom)
+    result = upnp.scan()
+    assert result["score"] == 0
+    assert result["details"]["responders"] == []
+    assert result["details"]["warnings"] == []
+
+
 def test_dns_scan_collects_answers(monkeypatch):
     class FakeAnswer:
         def __init__(self, rdata):


### PR DESCRIPTION
## Summary
- implement UPnP SSDP discovery and warn on responses
- include results in static scan UI tile

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b2f1225b883239296530fc772728b