### PR TITLE
feat: capture os and service banners

### DIFF
--- a/nw_checker/.gitattributes
+++ b/nw_checker/.gitattributes
@@ -1,0 +1,4 @@
+* text=auto eol=lf
+*.dart text eol=lf
+*.py   text eol=lf
+*.sh   text eol=lf

--- a/nw_checker/test/static_scan_tab_test.dart
+++ b/nw_checker/test/static_scan_tab_test.dart
@@ -108,6 +108,63 @@ void main() {
     expect(find.text('情報取得失敗'), findsOneWidget);
   });
 
+  testWidgets('shows OS and service banners in tile', (tester) async {
+    Future<Map<String, dynamic>> mockScan() async {
+      return {
+        'summary': [],
+        'findings': [
+          {'category': 'ports', 'details': {'open_ports': []}},
+          {
+            'category': 'os_banner',
+            'details': {
+              'os': 'Linux',
+              'banners': {'80': 'http Apache'},
+            },
+          },
+          {
+            'category': 'smb_netbios',
+            'details': {'smb1_enabled': false, 'netbios_names': []},
+          },
+          {
+            'category': 'upnp',
+            'details': {'responders': [], 'warnings': []},
+          },
+          {
+            'category': 'arp_spoof',
+            'details': {
+              'vulnerable': false,
+              'explanation': 'No ARP poisoning detected',
+            },
+          },
+          {
+            'category': 'dhcp',
+            'details': {
+              'servers': ['1.1.1.1'],
+              'warnings': [],
+            },
+          },
+        ],
+      };
+    }
+
+    await tester.pumpWidget(
+      MaterialApp(home: StaticScanTab(scanner: mockScan)),
+    );
+
+    await tester.tap(find.byKey(const Key('staticButton')));
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    final chips = tester.widgetList<Chip>(find.byType(Chip)).toList();
+    final osLabel = chips[1].label as Text;
+    expect(osLabel.data, 'OK');
+
+    await tester.tap(find.text('OS / Services'));
+    await tester.pumpAndSettle();
+    expect(find.text('OS: Linux'), findsOneWidget);
+    expect(find.text('ポート 80: http Apache'), findsOneWidget);
+  });
+
   testWidgets('SMBv1 enabled shows warning in tile', (tester) async {
     Future<Map<String, dynamic>> mockScan() async {
       return {

--- a/src/scans/os_banner.py
+++ b/src/scans/os_banner.py
@@ -13,6 +13,7 @@ def scan(target: str = "127.0.0.1") -> dict:
     scanner = nmap.PortScanner()
     banners: dict[int, str] = {}
     os_name = ""
+    error = ""
     try:
         result = scanner.scan(target, arguments="-O -sV --top-ports 10")
         host_info = result.get("scan", {}).get(target, {})
@@ -20,7 +21,9 @@ def scan(target: str = "127.0.0.1") -> dict:
         # サービスバナー取得
         tcp_info = host_info.get("tcp", {})
         for port, data in tcp_info.items():
-            banner = " ".join(filter(None, [data.get("name"), data.get("version")])).strip()
+            banner = " ".join(
+                filter(None, [data.get("name"), data.get("version")])
+            ).strip()
             if banner:
                 banners[int(port)] = banner
 
@@ -28,13 +31,12 @@ def scan(target: str = "127.0.0.1") -> dict:
         os_match = host_info.get("osmatch", [])
         if os_match:
             os_name = os_match[0].get("name", "")
-    except Exception:  # pragma: no cover - 外部コマンド失敗時は無視
-        pass
+    except Exception as exc:  # pragma: no cover - 外部コマンド失敗時は無視
+        error = str(exc)
 
     score = len(banners) + (1 if os_name else 0)
-    return {
-        "category": "os_banner",
-        "score": score,
-        "details": {"target": target, "os": os_name, "banners": banners},
-    }
+    details = {"target": target, "os": os_name, "banners": banners}
+    if error:
+        details["error"] = error
+    return {"category": "os_banner", "score": score, "details": details}
 

--- a/tests/test_scan_modules.py
+++ b/tests/test_scan_modules.py
@@ -96,6 +96,19 @@ def test_os_banner_scan_handles_no_results(monkeypatch):
     assert result["details"]["os"] == ""
 
 
+def test_os_banner_scan_handles_exception(monkeypatch):
+    class MockScanner:
+        def scan(self, target, arguments=""):
+            raise os_banner.nmap.PortScannerError("nmap error")
+
+    monkeypatch.setattr(os_banner.nmap, "PortScanner", lambda: MockScanner())
+    result = os_banner.scan("host")
+    assert result["score"] == 0
+    assert result["details"]["banners"] == {}
+    assert result["details"]["os"] == ""
+    assert "nmap error" in result["details"]["error"]
+
+
 def test_smb_netbios_scan_detects_smb1(monkeypatch):
     class DummyNB:
         def queryIPForName(self, target, timeout=2):  # noqa: D401, ARG002


### PR DESCRIPTION
## Summary
- handle OS and service banner scanning via nmap with error reporting
- add test covering nmap failure path and OS/service display in UI

## Testing
- `pytest -q`
- `cd nw_checker && flutter test -r expanded`


------
https://chatgpt.com/codex/tasks/task_e_689b2b51684083239cb7caf2d0ea4fe0