### PR TITLE
feat: enqueue packets captured via AsyncSniffer

### DIFF
--- a/nw_checker/.gitattributes
+++ b/nw_checker/.gitattributes
@@ -1,0 +1,4 @@
+* text=auto eol=lf
+*.dart text eol=lf
+*.py   text eol=lf
+*.sh   text eol=lf

--- a/tests/test_dynamic_scan_capture.py
+++ b/tests/test_dynamic_scan_capture.py
@@ -1,4 +1,5 @@
 import asyncio
+import pytest
 
 from src.dynamic_scan import capture
 
@@ -52,3 +53,35 @@ def test_capture_packets_stops_after_duration(monkeypatch):
     assert FakeSniffer.instance.started is True
     assert FakeSniffer.instance.stopped is True
     assert fake_sleep.called == 1
+
+
+def test_capture_packets_stops_when_cancelled(monkeypatch):
+    class FakeSniffer:
+        def __init__(self, iface=None, prn=None):
+            self.started = False
+            self.stopped = False
+            FakeSniffer.instance = self
+
+        def start(self):
+            self.started = True
+
+        def stop(self):  # pragma: no cover - nothing to do in test
+            self.stopped = True
+
+    # AsyncSniffer をモックし、capture_packets 内で使用する
+    monkeypatch.setattr(capture, "AsyncSniffer", FakeSniffer)
+
+    queue: asyncio.Queue = asyncio.Queue()
+
+    async def run_and_cancel():
+        # duration=None で起動し、タスクをキャンセル
+        task = asyncio.create_task(capture.capture_packets(queue))
+        await asyncio.sleep(0)
+        assert FakeSniffer.instance.started is True
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    asyncio.run(run_and_cancel())
+
+    assert FakeSniffer.instance.stopped is True


### PR DESCRIPTION
## Summary
- capture packets asynchronously with AsyncSniffer
- enqueue captured packets onto `asyncio.Queue`
- add unit test ensuring sniffer stops when capture task is cancelled

## Testing
- `pytest tests/test_dynamic_scan_capture.py`


------
https://chatgpt.com/codex/tasks/task_e_689b2bca8ad4832388e102f3aadc21e9