### PR TITLE
Handle ARP table errors in arp spoof scan

### DIFF
--- a/src/scans/arp_spoof.py
+++ b/src/scans/arp_spoof.py
@@ -48,7 +48,15 @@ def scan(
         ``fake_ip`` に紐付ける偽のMACアドレス。
     """
 
-    before = _get_arp_table()
+    try:
+        before = _get_arp_table()
+    except Exception as exc:
+        # ARPテーブル取得失敗時はエラー内容を返す
+        return {
+            "category": "arp_spoof",
+            "score": 0,
+            "details": {"error": str(exc)},
+        }
 
     try:
         pkt = ARP(
@@ -67,7 +75,15 @@ def scan(
             "details": {"error": str(exc)},
         }
 
-    after = _get_arp_table()
+    try:
+        after = _get_arp_table()
+    except Exception as exc:
+        return {
+            "category": "arp_spoof",
+            "score": 0,
+            "details": {"error": str(exc)},
+        }
+
     changed = before.get(fake_ip) != fake_mac and after.get(fake_ip) == fake_mac
     explanation = (
         "ARP table updated with spoofed entry"

--- a/tests/test_scan_modules.py
+++ b/tests/test_scan_modules.py
@@ -403,6 +403,23 @@ def test_arp_spoof_scan_handles_send_error(monkeypatch):
     assert "send error" in result["details"].get("error", "")
 
 
+def test_arp_spoof_scan_handles_table_error(monkeypatch):
+    """ARPテーブル取得エラー時の挙動を確認。"""
+
+    def boom():  # noqa: D401
+        raise RuntimeError("table fail")
+
+    monkeypatch.setattr(arp_spoof, "_get_arp_table", boom)
+    result = arp_spoof.scan(wait=0)
+    assert result == {
+        "category": "arp_spoof",
+        "score": 0,
+        "details": {"error": "table fail"},
+    }
+    assert "vulnerable" not in result["details"]
+    assert "explanation" not in result["details"]
+
+
 # --- SSL certificate -----------------------------------------------------
 
 def test_ssl_cert_scan_flags_expired(monkeypatch):


### PR DESCRIPTION
## Summary
- handle exceptions from `_get_arp_table` in `arp_spoof.scan` and return error details
- add regression test ensuring ARP table retrieval errors produce safe result

## Testing
- `pytest tests/test_scan_modules.py::test_arp_spoof_scan_handles_table_error -q`

------
https://chatgpt.com/codex/tasks/task_e_689b39dcd59083239ae3bd2a43ee3e3d