### PR TITLE
test: add arp table parsing tests

### DIFF
--- a/tests/test_arp_table.py
+++ b/tests/test_arp_table.py
@@ -30,3 +30,12 @@ invalid line without expected format
     }
     assert "10.0.0.2" not in table
     assert "10.0.0.3" not in table
+
+
+def test_get_arp_table_handles_subprocess_error(monkeypatch):
+    def boom(*args, **kwargs):
+        raise OSError("arp failed")
+
+    monkeypatch.setattr(subprocess, "check_output", boom)
+
+    assert _get_arp_table() == {}


### PR DESCRIPTION
## Summary
- test `_get_arp_table` parses ARP output and ignores malformed lines

## Testing
- `pytest tests/test_arp_table.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689b39dd3234832380069b7718461d75