### PR TITLE
Load DNS blacklist from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## DNS Blacklist
 
 The dynamic scan compares reverse DNS results against a configurable
-blacklist. Edit `data/dns_blacklist.txt` to add or remove domains. Each
-non-empty line should contain a single domain name; lines beginning with
-`#` are treated as comments.
+blacklist. Edit `data/dns_blacklist.txt` to add or remove domains. This
+file is loaded at startup; each non-empty line should contain a single
+domain name, and lines beginning with `#` are treated as comments.
 

--- a/data/dns_blacklist.txt
+++ b/data/dns_blacklist.txt
@@ -1,2 +1,4 @@
 # Default DNS blacklist
 malicious.example
+phishing.test
+botnet.example.org

--- a/src/dynamic_scan/analyze.py
+++ b/src/dynamic_scan/analyze.py
@@ -14,15 +14,12 @@ DANGEROUS_PROTOCOLS = {"telnet", "ftp", "rdp"}
 
 
 def load_blacklist(path: str = "data/dns_blacklist.txt") -> set[str]:
-    try:
-        with open(path) as f:
-            return {
-                line.strip()
-                for line in f
-                if line.strip() and not line.startswith("#")
-            }
-    except FileNotFoundError:
-        return set()
+    with open(path) as f:
+        return {
+            line.strip()
+            for line in f
+            if line.strip() and not line.startswith("#")
+        }
 
 
 # DNS 逆引きのブラックリスト

--- a/tests/test_dynamic_scan_analyze.py
+++ b/tests/test_dynamic_scan_analyze.py
@@ -118,7 +118,8 @@ def test_load_blacklist(tmp_path):
 
 def test_load_blacklist_missing_file(tmp_path):
     missing = tmp_path / "no_such_file.txt"
-    assert analyze.load_blacklist(missing) == set()
+    with pytest.raises(FileNotFoundError):
+        analyze.load_blacklist(missing)
 
 
 def test_load_blacklist_default_file():


### PR DESCRIPTION
## Summary
- load DNS blacklist from data/dns_blacklist.txt at startup
- document blacklist file path for operators
- update tests for new blacklist loader

## Testing
- `pytest tests/test_dynamic_scan_analyze.py`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_689bc618ec6083238ceb8cff85b87a38