### PR TITLE
feat: add DHCP discovery scan

### DIFF
--- a/src/scans/dhcp.py
+++ b/src/scans/dhcp.py
@@ -1,4 +1,10 @@
-"""Static scan for rogue DHCP servers using scapy."""
+"""Static scan for rogue DHCP servers using scapy.
+
+This scan broadcasts a DHCP *discover* packet and counts how many
+servers answer. The IP address of each responding server is recorded and
+a warning is emitted when multiple servers respond, which may indicate a
+configuration conflict in the network.
+"""
 
 from scapy.all import (  # type: ignore
     Ether,

--- a/tests/test_scan_modules.py
+++ b/tests/test_scan_modules.py
@@ -372,6 +372,17 @@ def test_dhcp_scan_deduplicates_servers(monkeypatch):
     assert result["details"]["servers"] == ["10.0.0.1"]
 
 
+def test_dhcp_scan_no_servers(monkeypatch):
+    """No responses should yield empty server list and no warnings."""
+
+    monkeypatch.setattr(dhcp, "srp", lambda *_, **__: ([], None))
+    result = dhcp.scan()
+    assert result["score"] == 0
+    assert result["details"]["servers"] == []
+    assert result["details"]["warnings"] == []
+    assert "error" not in result["details"]
+
+
 def test_dhcp_scan_handles_errors(monkeypatch):
     """srp raising should surface an error and score 0."""
 


### PR DESCRIPTION
## Summary
- add scapy-based DHCP discover scan returning server IPs and conflict warnings
- ensure DHCP findings populate the 6th static scan tile
- test DHCP scan when no servers respond
- test DHCP aggregation in static scan results

## Testing
- `PYTHONPATH=src:src/scans pytest tests/test_scan_modules.py::test_dhcp_scan_no_servers tests/test_scan_modules.py::test_dhcp_scan_detects_servers tests/test_scan_modules.py::test_dhcp_scan_warns_on_conflict tests/test_scan_modules.py::test_dhcp_scan_deduplicates_servers tests/test_scan_modules.py::test_dhcp_scan_handles_errors tests/test_static_scan.py::test_run_all_returns_all_categories tests/test_static_scan.py::test_run_all_totals_scores tests/test_static_scan.py::test_run_all_is_json_serializable tests/test_static_scan.py::test_run_all_populates_missing_fields tests/test_static_scan.py::test_run_all_includes_dhcp_details -q`

------
https://chatgpt.com/codex/tasks/task_e_689b4580ca1483239bf4f852b6c975e8