### PR TITLE
Remove obsolete ARP spoof send error test

### DIFF
--- a/tests/test_scan_modules.py
+++ b/tests/test_scan_modules.py
@@ -440,25 +440,6 @@ def test_arp_spoof_custom_ip_mac(monkeypatch):
     }
 
 
-import arp_spoof
-
-
-@pytest.mark.parametrize("message", ["send fail", "send error"])
-def test_arp_spoof_scan_handles_send_error(monkeypatch, message):
-    """send() が失敗した場合は score=0 を返し、エラーメッセージに内容を含める。"""
-
-    def boom(*args, **kwargs):  # noqa: D401, ARG001
-        raise RuntimeError(message)
-
-    monkeypatch.setattr(arp_spoof, "send", failing_send)
-    result = arp_spoof.scan(wait=0)
-    assert result["score"] == 0
-    assert "send error" in result["details"]["error"]
-    assert result["category"] == "arp_spoof"
-    assert result["details"] == {"error": "send fail"}
-
-
-
 def test_arp_spoof_scan_handles_table_error(monkeypatch):
     """ARPテーブル取得エラー時の挙動を確認。"""
 


### PR DESCRIPTION
## Summary
- remove duplicate `test_arp_spoof_scan_handles_send_error` that referenced undefined `failing_send`
- keep the valid send error test

## Testing
- `PYTHONPATH=src:src/scans pytest tests/test_scan_modules.py`
- `cd nw_checker && flutter test`


------
https://chatgpt.com/codex/tasks/task_e_689b45709b1c83239e5f46119df0d520