### PR TITLE
feat: add DNS scan warnings for external servers and DNSSEC

### DIFF
--- a/nw_checker/test/static_scan_tab_test.dart
+++ b/nw_checker/test/static_scan_tab_test.dart
@@ -622,7 +622,7 @@ void main() {
           {
             'category': 'dns',
             'details': {
-              'warnings': ['外部DNSが検出されました: 8.8.8.8'],
+              'warnings': ['External DNS detected: 8.8.8.8'],
               'servers': ['8.8.8.8'],
               'dnssec_enabled': false,
             },
@@ -648,6 +648,6 @@ void main() {
     expect(dnsLabel.data, '警告');
     await tester.tap(find.text('DNS'));
     await tester.pumpAndSettle();
-    expect(find.text('外部DNSが検出されました: 8.8.8.8'), findsOneWidget);
+    expect(find.text('External DNS detected: 8.8.8.8'), findsOneWidget);
   });
 }

--- a/src/scans/dns.py
+++ b/src/scans/dns.py
@@ -50,10 +50,11 @@ def scan() -> dict:
     details = {"servers": servers}
 
     if external:
-        warnings.append("外部DNSが検出されました: " + ", ".join(external))
+        # 外部DNSサーバーを使用している場合は警告
+        warnings.append("External DNS detected: " + ", ".join(external))
         details["external_servers"] = external
 
-    dnssec_enabled = False
+    dnssec_enabled = None
     try:
         pkt = (
             IP(dst=servers[0])
@@ -66,9 +67,9 @@ def scan() -> dict:
     except Exception as exc:  # pragma: no cover
         details["error"] = str(exc)
 
-    details["dnssec_enabled"] = dnssec_enabled
-    if not dnssec_enabled:
-        warnings.append("DNSSECが無効です")
+    details["dnssec_enabled"] = bool(dnssec_enabled)
+    if dnssec_enabled is False:
+        warnings.append("DNSSEC is disabled")
 
     details["warnings"] = warnings
     score = len(warnings)

--- a/tests/test_scan_modules.py
+++ b/tests/test_scan_modules.py
@@ -300,7 +300,7 @@ def test_dns_scan_flags_external_dns(monkeypatch):
     monkeypatch.setattr(dns, "sr1", lambda *_, **__: FakeResp())
     result = dns.scan()
     warnings = result["details"]["warnings"]
-    assert any("外部DNSが検出されました" in w for w in warnings)
+    assert any("External DNS detected" in w for w in warnings)
 
 
 def test_dns_scan_flags_dnssec_disabled(monkeypatch):
@@ -318,7 +318,7 @@ def test_dns_scan_flags_dnssec_disabled(monkeypatch):
     monkeypatch.setattr(dns, "sr1", lambda *_, **__: FakeResp())
     result = dns.scan()
     warnings = result["details"]["warnings"]
-    assert "DNSSECが無効です" in warnings
+    assert "DNSSEC is disabled" in warnings
 
 
 def test_dns_scan_handles_error(monkeypatch):


### PR DESCRIPTION
## Summary
- report external DNS servers and DNSSEC disabled situations
- update tests and Flutter UI to show English warnings

## Testing
- `pytest tests/test_scan_modules.py::test_dns_scan_flags_external_dns`
- `pytest tests/test_scan_modules.py::test_dns_scan_flags_dnssec_disabled`
- `pytest tests/test_scan_modules.py::test_dns_scan_handles_error`
- `cd nw_checker && flutter test test/static_scan_tab_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_689bd01fe49c8323a899db063f4f6cad