### PR TITLE
Implement dynamic scan storage and scheduler

### DIFF
--- a/src/dynamic_scan/scheduler.py
+++ b/src/dynamic_scan/scheduler.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from contextlib import suppress
-from typing import Iterable, Optional
+from typing import Iterable
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 
@@ -56,6 +56,7 @@ class DynamicScanScheduler:
             "interval",
             seconds=interval,
             args=[interface, duration, approved_macs],
+            max_instances=1,
         )
 
     async def stop(self) -> None:

--- a/src/dynamic_scan/storage.py
+++ b/src/dynamic_scan/storage.py
@@ -1,7 +1,7 @@
 import json
 import asyncio
 import sqlite3
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List
 
@@ -41,7 +41,7 @@ class Storage:
 
     async def save_result(self, data: Dict[str, Any]) -> None:
         """結果を保存し、リスナーへ通知"""
-        from datetime import datetime, timezone
+        # タイムゾーン付きISO形式でタイムスタンプを付与
         record = {"timestamp": datetime.now(timezone.utc).isoformat(), **data}
 
         async with self._lock:
@@ -51,6 +51,7 @@ class Storage:
             q.put_nowait(record)
 
     def _insert_record(self, record: Dict[str, Any]) -> None:
+        """SQLite に 1 件のレコードを書き込む"""
         with sqlite3.connect(self.db_path) as conn:
             conn.execute(
                 "INSERT INTO results (timestamp, data) VALUES (?, ?)",

--- a/tests/test_dynamic_scan_storage.py
+++ b/tests/test_dynamic_scan_storage.py
@@ -48,3 +48,14 @@ def test_storage_fetch_out_of_range(tmp_path):
     end = (now + timedelta(days=2)).isoformat()
     history = store.fetch_history({"start": start, "end": end})
     assert history == []
+
+
+def test_fetch_results_range(tmp_path):
+    store = Storage(tmp_path / "res.db")
+    asyncio.run(store.save_result({"id": 1}))
+    asyncio.run(store.save_result({"id": 2}))
+
+    today = datetime.now().date().isoformat()
+    results = store.fetch_results(today, today)
+    ids = [r["id"] for r in results]
+    assert ids == [1, 2]


### PR DESCRIPTION
## Summary
- persist scan results to SQLite and broadcast updates to listeners
- schedule capture and analysis tasks using APScheduler
- add tests for fetch_results range queries

## Testing
- `pytest tests/test_dynamic_scan_storage.py tests/test_dynamic_scan_scheduler.py`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_689bd02e9c408323aeb1dccdda6d70a3