### PR TITLE
feat: add DNS scan warnings for external, invalid servers and DNSSEC

### DIFF
--- a/nw_checker/test/static_scan_tab_test.dart
+++ b/nw_checker/test/static_scan_tab_test.dart
@@ -622,7 +622,7 @@ void main() {
           {
             'category': 'dns',
             'details': {
-              'warnings': ['外部DNSが検出されました: 8.8.8.8'],
+              'warnings': ['External DNS detected: 8.8.8.8'],
               'servers': ['8.8.8.8'],
               'dnssec_enabled': false,
             },
@@ -648,6 +648,73 @@ void main() {
     expect(dnsLabel.data, '警告');
     await tester.tap(find.text('DNS'));
     await tester.pumpAndSettle();
-    expect(find.text('外部DNSが検出されました: 8.8.8.8'), findsOneWidget);
+    expect(find.text('External DNS detected: 8.8.8.8'), findsOneWidget);
+  });
+
+  testWidgets('invalid DNS server shows warning in tile', (tester) async {
+    Future<Map<String, dynamic>> mockScan() async {
+      return {
+        'summary': [],
+        'findings': [
+          {
+            'category': 'ports',
+            'details': {'open_ports': []},
+          },
+          {
+            'category': 'os_banner',
+            'details': {'os': 'Linux', 'banners': {}},
+          },
+          {
+            'category': 'smb_netbios',
+            'details': {'smb1_enabled': false, 'netbios_names': []},
+          },
+          {
+            'category': 'upnp',
+            'details': {'responders': [], 'warnings': []},
+          },
+          {
+            'category': 'arp_spoof',
+            'details': {
+              'vulnerable': false,
+              'explanation': 'No ARP poisoning detected',
+            },
+          },
+          {
+            'category': 'dhcp',
+            'details': {
+              'servers': ['1.1.1.1'],
+              'warnings': [],
+            },
+          },
+          {
+            'category': 'dns',
+            'details': {
+              'warnings': ['Invalid DNS server IP: bad_ip'],
+              'servers': ['bad_ip'],
+              'dnssec_enabled': false,
+            },
+          },
+          {
+            'category': 'ssl_cert',
+            'details': {'host': 'example.com', 'expired': false},
+          },
+        ],
+      };
+    }
+
+    await tester.pumpWidget(
+      MaterialApp(home: StaticScanTab(scanner: mockScan)),
+    );
+
+    await tester.tap(find.byKey(const Key('staticButton')));
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    final chips = tester.widgetList<Chip>(find.byType(Chip)).toList();
+    final dnsLabel = chips[6].label as Text;
+    expect(dnsLabel.data, '警告');
+    await tester.tap(find.text('DNS'));
+    await tester.pumpAndSettle();
+    expect(find.text('Invalid DNS server IP: bad_ip'), findsOneWidget);
   });
 }

--- a/src/scans/dns.py
+++ b/src/scans/dns.py
@@ -44,31 +44,47 @@ def scan() -> dict:
     """DNS設定を検査し、問題があれば警告を返す。"""
 
     servers = _get_nameservers()
-    external = [ip for ip in servers if not _is_private(ip)]
+
+    external: List[str] = []
+    invalid: List[str] = []
+    for ip in servers:
+        try:
+            addr = ip_address(ip)
+            if not any(addr in net for net in _PRIVATE_NETS):
+                external.append(ip)
+        except ValueError:
+            invalid.append(ip)
 
     warnings: List[str] = []
     details = {"servers": servers}
 
     if external:
-        warnings.append("外部DNSが検出されました: " + ", ".join(external))
+        # 外部DNSサーバーを使用している場合は警告
+        warnings.append("External DNS detected: " + ", ".join(external))
         details["external_servers"] = external
 
-    dnssec_enabled = False
+    if invalid:
+        warnings.append("Invalid DNS server IP: " + ", ".join(invalid))
+        details["invalid_servers"] = invalid
+
+    dnssec_enabled = None
     try:
-        pkt = (
-            IP(dst=servers[0])
-            / UDP(dport=53)
-            / DNS(rd=1, qd=DNSQR(qname="example.com"), ad=1)
-        )
-        resp = sr1(pkt, timeout=2, verbose=False)
-        if resp and resp.haslayer(DNS):
-            dnssec_enabled = bool(getattr(resp[DNS], "ad", 0))
+        valid = [ip for ip in servers if ip not in invalid]
+        if valid:
+            pkt = (
+                IP(dst=valid[0])
+                / UDP(dport=53)
+                / DNS(rd=1, qd=DNSQR(qname="example.com"), ad=1)
+            )
+            resp = sr1(pkt, timeout=2, verbose=False)
+            if resp and resp.haslayer(DNS):
+                dnssec_enabled = bool(getattr(resp[DNS], "ad", 0))
     except Exception as exc:  # pragma: no cover
         details["error"] = str(exc)
 
-    details["dnssec_enabled"] = dnssec_enabled
-    if not dnssec_enabled:
-        warnings.append("DNSSECが無効です")
+    details["dnssec_enabled"] = bool(dnssec_enabled)
+    if dnssec_enabled is False:
+        warnings.append("DNSSEC is disabled")
 
     details["warnings"] = warnings
     score = len(warnings)

--- a/tests/test_scan_modules.py
+++ b/tests/test_scan_modules.py
@@ -300,7 +300,7 @@ def test_dns_scan_flags_external_dns(monkeypatch):
     monkeypatch.setattr(dns, "sr1", lambda *_, **__: FakeResp())
     result = dns.scan()
     warnings = result["details"]["warnings"]
-    assert any("外部DNSが検出されました" in w for w in warnings)
+    assert any("External DNS detected" in w for w in warnings)
 
 
 def test_dns_scan_flags_dnssec_disabled(monkeypatch):
@@ -318,7 +318,7 @@ def test_dns_scan_flags_dnssec_disabled(monkeypatch):
     monkeypatch.setattr(dns, "sr1", lambda *_, **__: FakeResp())
     result = dns.scan()
     warnings = result["details"]["warnings"]
-    assert "DNSSECが無効です" in warnings
+    assert "DNSSEC is disabled" in warnings
 
 
 def test_dns_scan_handles_error(monkeypatch):
@@ -331,6 +331,17 @@ def test_dns_scan_handles_error(monkeypatch):
     result = dns.scan()
     assert result["score"] == 0
     assert "dns fail" in result["details"]["error"]
+
+
+def test_dns_scan_flags_invalid_server(monkeypatch):
+    """Invalid nameserver entries should trigger a warning."""
+
+    monkeypatch.setattr(
+        dns, "_get_nameservers", lambda path="/etc/resolv.conf": ["bad_ip"]
+    )
+    result = dns.scan()
+    warnings = result["details"]["warnings"]
+    assert any("Invalid DNS server IP" in w for w in warnings)
 
 
 def test_dhcp_scan_detects_servers(monkeypatch):


### PR DESCRIPTION
## Summary
- report external DNS servers and DNSSEC disabled situations
- warn on invalid DNS server entries and surface in Flutter UI

## Testing
- `pytest tests/test_scan_modules.py::test_dns_scan_flags_external_dns -q`
- `pytest tests/test_scan_modules.py::test_dns_scan_flags_dnssec_disabled -q`
- `pytest tests/test_scan_modules.py::test_dns_scan_handles_error -q`
- `pytest tests/test_scan_modules.py::test_dns_scan_flags_invalid_server -q`
- `cd nw_checker && flutter test test/static_scan_tab_test.dart`

------
https://chatgpt.com/codex/tasks/task_e_689bd01fe49c8323a899db063f4f6cad