### PR TITLE
Implement dynamic scan storage and scheduler

### DIFF
--- a/src/dynamic_scan/scheduler.py
+++ b/src/dynamic_scan/scheduler.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from contextlib import suppress
-from typing import Iterable, Optional
+from typing import Iterable
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 
@@ -56,6 +56,7 @@ class DynamicScanScheduler:
             "interval",
             seconds=interval,
             args=[interface, duration, approved_macs],
+            max_instances=1,
         )
 
     async def stop(self) -> None:

--- a/tests/test_dynamic_scan_storage.py
+++ b/tests/test_dynamic_scan_storage.py
@@ -48,3 +48,23 @@ def test_storage_fetch_out_of_range(tmp_path):
     end = (now + timedelta(days=2)).isoformat()
     history = store.fetch_history({"start": start, "end": end})
     assert history == []
+
+
+def test_fetch_results_range(tmp_path):
+    store = Storage(tmp_path / "res.db")
+    asyncio.run(store.save_result({"id": 1}))
+    asyncio.run(store.save_result({"id": 2}))
+
+    today = datetime.now().date().isoformat()
+    results = store.fetch_results(today, today)
+    ids = [r["id"] for r in results]
+    assert ids == [1, 2]
+
+
+def test_recent_limit(tmp_path):
+    store = Storage(tmp_path / "res.db", max_recent=2)
+    asyncio.run(store.save_result({"id": 1}))
+    asyncio.run(store.save_result({"id": 2}))
+    asyncio.run(store.save_result({"id": 3}))
+    ids = [r["id"] for r in store.get_all()]
+    assert ids == [2, 3]


### PR DESCRIPTION
## Summary
- persist scan results to SQLite and broadcast updates to listeners
- limit in-memory scan history and allow configuring maximum retained records
- schedule capture and analysis tasks using APScheduler and add tests for storage filters and range queries

## Testing
- `pytest tests/test_dynamic_scan_storage.py tests/test_dynamic_scan_scheduler.py`
- `flutter test --machine`


------
https://chatgpt.com/codex/tasks/task_e_689bd02e9c408323aeb1dccdda6d70a3