### PR TITLE
Schedule blacklist updater job

### DIFF
--- a/src/dynamic_scan/blacklist_updater.py
+++ b/src/dynamic_scan/blacklist_updater.py
@@ -74,6 +74,12 @@ def write_blacklist(domains: Set[str], path: str = "data/dns_blacklist.txt") -> 
         raise
 
 
+def update(feed_url: str, output_path: str = "data/dns_blacklist.txt") -> None:
+    """Fetch a feed and update blacklist file."""
+    domains = fetch_feed(feed_url)
+    write_blacklist(domains, output_path)
+
+
 def main(argv: Iterable[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="Update DNS blacklist from feeds")
     parser.add_argument("feeds", nargs="+", help="Feed URLs (CSV or JSON)")

--- a/src/dynamic_scan/config.json
+++ b/src/dynamic_scan/config.json
@@ -1,3 +1,5 @@
 {
-  "traffic_threshold": 1000000
+  "traffic_threshold": 1000000,
+  "blacklist_feed_url": "https://example.com/feed.json",
+  "blacklist_update_interval_hours": 12
 }

--- a/src/dynamic_scan/scheduler.py
+++ b/src/dynamic_scan/scheduler.py
@@ -1,12 +1,43 @@
 from __future__ import annotations
 
 import asyncio
+import json
+import os
 from contextlib import suppress
+from pathlib import Path
 from typing import Iterable
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 
-from . import capture, analyze, storage
+from . import blacklist_updater, capture, analyze, storage
+
+
+CONFIG_PATH = Path(__file__).with_name("config.json")
+
+
+def load_blacklist_config(path: Path | None = None) -> tuple[str | None, int]:
+    """環境変数または設定ファイルからブラックリスト更新設定を読み込む"""
+    path = path or CONFIG_PATH
+    feed_url = os.getenv("BLACKLIST_FEED_URL")
+    interval_env = os.getenv("BLACKLIST_UPDATE_INTERVAL_HOURS")
+    try:
+        interval_hours = int(interval_env) if interval_env is not None else None
+    except ValueError:
+        interval_hours = None
+    if not feed_url or interval_hours is None:
+        try:
+            with path.open("r", encoding="utf-8") as f:
+                data = json.load(f)
+            if not feed_url:
+                feed_url = data.get("blacklist_feed_url")
+            if interval_hours is None:
+                interval_hours = int(data.get("blacklist_update_interval_hours", 12))
+        except Exception:
+            if interval_hours is None:
+                interval_hours = 12
+    if interval_hours is None:
+        interval_hours = 12
+    return feed_url, interval_hours
 
 
 class DynamicScanScheduler:
@@ -15,6 +46,7 @@ class DynamicScanScheduler:
     def __init__(self) -> None:
         self.scheduler: AsyncIOScheduler | None = None
         self.job = None
+        self.blacklist_job = None
         self.capture_task: asyncio.Task | None = None
         self.analyse_task: asyncio.Task | None = None
         self.storage: storage.Storage = storage.Storage()
@@ -50,6 +82,8 @@ class DynamicScanScheduler:
             self.scheduler.start()
         if self.job:
             self.job.remove()
+        if self.blacklist_job:
+            self.blacklist_job.remove()
         # APScheduler でコルーチンを定期実行
         self.job = self.scheduler.add_job(
             self._run_scan,
@@ -58,12 +92,23 @@ class DynamicScanScheduler:
             args=[interface, duration, approved_macs],
             max_instances=1,
         )
+        feed_url, interval_hours = load_blacklist_config()
+        if feed_url:
+            self.blacklist_job = self.scheduler.add_job(
+                blacklist_updater.update,
+                "interval",
+                hours=interval_hours,
+                args=[feed_url],
+            )
 
     async def stop(self) -> None:
         """スケジュールされたジョブと進行中のタスクを停止"""
         if self.job:
             self.job.remove()
             self.job = None
+        if self.blacklist_job:
+            self.blacklist_job.remove()
+            self.blacklist_job = None
         for task in (self.capture_task, self.analyse_task):
             if task:
                 task.cancel()

--- a/tests/test_blacklist_updater.py
+++ b/tests/test_blacklist_updater.py
@@ -1,5 +1,5 @@
 import requests
-from src.dynamic_scan.blacklist_updater import fetch_feed, write_blacklist
+from src.dynamic_scan import blacklist_updater
 
 
 def test_fetch_feed_json(monkeypatch):
@@ -12,13 +12,13 @@ def test_fetch_feed_json(monkeypatch):
             pass
 
     monkeypatch.setattr(requests, "get", lambda url, timeout: Resp())
-    assert fetch_feed("http://example.com/feed.json") == {"a.com", "b.org"}
+    assert blacklist_updater.fetch_feed("http://example.com/feed.json") == {"a.com", "b.org"}
 
 
 def test_write_blacklist(tmp_path):
     path = tmp_path / "dns_blacklist.txt"
     path.write_text("# header\nold.com\n")
-    write_blacklist({"new.com"}, path=str(path))
+    blacklist_updater.write_blacklist({"new.com"}, path=str(path))
     content = path.read_text().splitlines()
     assert "old.com" in content
     assert "new.com" in content
@@ -33,4 +33,22 @@ def test_fetch_feed_csv(monkeypatch):
             pass
 
     monkeypatch.setattr(requests, "get", lambda url, timeout: Resp())
-    assert fetch_feed("http://example.com/feed.csv") == {"c.com", "d.org"}
+    assert blacklist_updater.fetch_feed("http://example.com/feed.csv") == {"c.com", "d.org"}
+
+
+def test_update(monkeypatch, tmp_path):
+    called = {"fetch": False, "write": False}
+
+    def fake_fetch(url):
+        called["fetch"] = True
+        return {"x.com"}
+
+    def fake_write(domains, path="data/dns_blacklist.txt"):
+        called["write"] = True
+        assert domains == {"x.com"}
+        assert path == str(tmp_path / "out.txt")
+
+    monkeypatch.setattr(blacklist_updater, "fetch_feed", fake_fetch)
+    monkeypatch.setattr(blacklist_updater, "write_blacklist", fake_write)
+    blacklist_updater.update("http://feed", output_path=str(tmp_path / "out.txt"))
+    assert called["fetch"] and called["write"]

--- a/tests/test_dynamic_scan_scheduler.py
+++ b/tests/test_dynamic_scan_scheduler.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 
 from src.dynamic_scan import scheduler, capture, analyze, storage
 
@@ -15,10 +16,15 @@ def test_scheduler_start_and_stop(monkeypatch):
 
         monkeypatch.setattr(capture, "capture_packets", dummy_capture)
         monkeypatch.setattr(analyze, "analyse_packets", dummy_analyse)
+        monkeypatch.setenv("BLACKLIST_FEED_URL", "http://example.com/feed.json")
+        monkeypatch.setenv("BLACKLIST_UPDATE_INTERVAL_HOURS", "1")
+        monkeypatch.setattr(scheduler.blacklist_updater, "update", lambda url: None)
 
         sched.start(duration=0, interval=1)
         assert sched.scheduler is not None
         assert sched.job is not None
+        assert sched.blacklist_job is not None
+        assert sched.blacklist_job.args == ["http://example.com/feed.json"]
 
         # ダミータスクを設定し stop でキャンセルされるか確認
         t1 = asyncio.create_task(asyncio.sleep(1))
@@ -29,6 +35,7 @@ def test_scheduler_start_and_stop(monkeypatch):
         await sched.stop()
         assert sched.scheduler is None
         assert sched.job is None
+        assert sched.blacklist_job is None
         assert t1.cancelled()
         assert t2.cancelled()
         assert sched.capture_task is None
@@ -56,5 +63,28 @@ def test_run_scan_executes_tasks(monkeypatch, tmp_path):
         assert flags["capture"] and flags["analyse"]
         assert sched.capture_task is None
         assert sched.analyse_task is None
+
+    asyncio.run(inner())
+
+
+def test_scheduler_loads_config(monkeypatch, tmp_path):
+    async def inner():
+        config_path = tmp_path / "config.json"
+        config_path.write_text(
+            json.dumps({
+                "blacklist_feed_url": "http://conf.example.com/feed.csv",
+                "blacklist_update_interval_hours": 2,
+            })
+        )
+        monkeypatch.delenv("BLACKLIST_FEED_URL", raising=False)
+        monkeypatch.delenv("BLACKLIST_UPDATE_INTERVAL_HOURS", raising=False)
+        monkeypatch.setattr(scheduler, "CONFIG_PATH", config_path)
+        monkeypatch.setattr(scheduler.blacklist_updater, "update", lambda url: None)
+
+        sched = scheduler.DynamicScanScheduler()
+        sched.start(duration=0, interval=1)
+        assert sched.blacklist_job is not None
+        assert sched.blacklist_job.args == ["http://conf.example.com/feed.csv"]
+        await sched.stop()
 
     asyncio.run(inner())


### PR DESCRIPTION
## Summary
- run DNS blacklist updater on a separate APScheduler job
- read updater interval and feed URL from environment or config
- document defaults in dynamic scan config

## Testing
- `pytest` *(fails: ImportError cannot import name 'IP' from '<unknown module name>' in scapy)*

------
https://chatgpt.com/codex/tasks/task_e_689bf8fd8d7c8323a6e21a5ccb776c9d