### PR TITLE
Add blacklist updater tests and mock load_blacklist

### DIFF
--- a/tests/test_dynamic_scan_analyze.py
+++ b/tests/test_dynamic_scan_analyze.py
@@ -274,6 +274,9 @@ def test_record_dns_history_no_hostname(monkeypatch):
 
 def test_record_dns_history_uses_loaded_blacklist(monkeypatch):
     analyze._dns_history.clear()
+    monkeypatch.setattr(
+        analyze, "load_blacklist", lambda path="data/dns_blacklist.txt": {"malicious.example"}
+    )
     analyze.DNS_BLACKLIST = analyze.load_blacklist()
     monkeypatch.setattr(
         analyze.socket, "gethostbyaddr", lambda ip: ("malicious.example", [], [])


### PR DESCRIPTION
## Summary
- test `load_blacklist` parses domain lists
- cover `update` by integrating `fetch_feed` and `write_blacklist`
- mock `load_blacklist` in DNS history test to avoid file I/O

## Testing
- `pytest tests/test_blacklist_updater.py tests/test_dynamic_scan_analyze.py`

------
https://chatgpt.com/codex/tasks/task_e_689c1a32e5a88323bc7231455caca2a8