### PR TITLE
Expand blacklist updater tests and mock load_blacklist

### DIFF
--- a/tests/test_blacklist_updater.py
+++ b/tests/test_blacklist_updater.py
@@ -1,5 +1,5 @@
 import requests
-from src.dynamic_scan import blacklist_updater
+from src.dynamic_scan import analyze, blacklist_updater
 
 
 def test_fetch_feed_json(monkeypatch):
@@ -36,19 +36,38 @@ def test_fetch_feed_csv(monkeypatch):
     assert blacklist_updater.fetch_feed("http://example.com/feed.csv") == {"c.com", "d.org"}
 
 
-def test_update(monkeypatch, tmp_path):
-    called = {"fetch": False, "write": False}
+def test_load_blacklist(tmp_path):
+    blk = tmp_path / "dns_blacklist.txt"
+    blk.write_text("# comment\nfoo.example\nbar.example\n")
+    assert analyze.load_blacklist(str(blk)) == {"foo.example", "bar.example"}
 
-    def fake_fetch(url):
-        called["fetch"] = True
-        return {"x.com"}
 
-    def fake_write(domains, path="data/dns_blacklist.txt"):
-        called["write"] = True
-        assert domains == {"x.com"}
-        assert path == str(tmp_path / "out.txt")
+def test_update_integration(monkeypatch, tmp_path):
+    class Resp:
+        def __init__(self):
+            self.text = "x.com\n#c\ny.org"
+            self.headers = {"Content-Type": "text/plain"}
 
-    monkeypatch.setattr(blacklist_updater, "fetch_feed", fake_fetch)
-    monkeypatch.setattr(blacklist_updater, "write_blacklist", fake_write)
-    blacklist_updater.update("http://feed", output_path=str(tmp_path / "out.txt"))
-    assert called["fetch"] and called["write"]
+        def raise_for_status(self):
+            pass
+
+    monkeypatch.setattr(requests, "get", lambda url, timeout: Resp())
+    out = tmp_path / "out.txt"
+    blacklist_updater.update("http://feed", output_path=str(out))
+    lines = out.read_text().splitlines()
+    assert "x.com" in lines and "y.org" in lines
+    assert lines[0].startswith("#")
+
+
+def test_fetch_feed_error(monkeypatch):
+    def fake_get(url, timeout):  # pragma: no cover - 例外発生の確認用
+        raise requests.RequestException("boom")
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    assert blacklist_updater.fetch_feed("http://example.com/feed") == set()
+
+
+def test_write_blacklist_no_domains(tmp_path):
+    path = tmp_path / "dns_blacklist.txt"
+    blacklist_updater.write_blacklist(set(), path=str(path))
+    assert not path.exists()

--- a/tests/test_dynamic_scan_analyze.py
+++ b/tests/test_dynamic_scan_analyze.py
@@ -274,6 +274,9 @@ def test_record_dns_history_no_hostname(monkeypatch):
 
 def test_record_dns_history_uses_loaded_blacklist(monkeypatch):
     analyze._dns_history.clear()
+    monkeypatch.setattr(
+        analyze, "load_blacklist", lambda path="data/dns_blacklist.txt": {"malicious.example"}
+    )
     analyze.DNS_BLACKLIST = analyze.load_blacklist()
     monkeypatch.setattr(
         analyze.socket, "gethostbyaddr", lambda ip: ("malicious.example", [], [])


### PR DESCRIPTION
## Summary
- test `load_blacklist` parses domain lists
- cover `update` by integrating `fetch_feed` and `write_blacklist`
- mock `load_blacklist` in DNS history test to avoid file I/O
- ensure `fetch_feed` returns empty on errors and `write_blacklist` skips when no domains

## Testing
- `pytest tests/test_blacklist_updater.py tests/test_dynamic_scan_analyze.py`


------
https://chatgpt.com/codex/tasks/task_e_689c1a32e5a88323bc7231455caca2a8