### PR TITLE
Mock external discovery for deterministic tests

### DIFF
--- a/src/discover_hosts.py
+++ b/src/discover_hosts.py
@@ -1,13 +1,42 @@
-"""
-LAN host discovery utilities.
-"""
+"""LAN host discovery utilities."""
+
+import socket
+import subprocess
+
+
+def _verify_host(ip: str, port: int = 80, timeout: float = 0.1) -> bool:
+    """Verify that a host responds on the given port.
+
+    A simple TCP connection attempt is used to check reachability.  This
+    function is intentionally lightweight so that it can be easily mocked in
+    tests without performing real network operations.
+    """
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        sock.settimeout(timeout)
+        sock.connect((ip, port))
+        return True
+    except OSError:
+        return False
+    finally:
+        sock.close()
+
 
 def discover_hosts(subnet: str):
-    """
-    Discover devices in the given subnet.
+    """Discover devices in the given subnet.
+
+    The current implementation delegates the heavy lifting to an external
+    command that lists candidate hosts (one IP address per line).  Each
+    candidate is probed via :func:`_verify_host` to confirm that it is
+    reachable.
+
     Returns:
-        list of IP addresses or host details.
+        list of IP addresses for hosts that responded.
     """
-    # 現状はスキャンを行わず空のリストを返す（後で実装予定）
-    # TODO: Implement real host discovery.
-    return []
+    try:
+        output = subprocess.check_output(["discover_hosts", subnet], text=True)
+    except (OSError, subprocess.CalledProcessError):
+        return []
+
+    candidates = [line.strip() for line in output.splitlines() if line.strip()]
+    return [ip for ip in candidates if _verify_host(ip)]

--- a/tests/test_discover_hosts.py
+++ b/tests/test_discover_hosts.py
@@ -1,6 +1,38 @@
-import pytest
+"""Tests for :func:`discover_hosts`."""
+
+import socket
+import subprocess
+
 from src.discover_hosts import discover_hosts
 
-def test_discover_hosts_runs():
+
+def test_discover_hosts_monkeypatched(monkeypatch):
+    """Ensure host discovery is independent from the external environment."""
+
+    def fake_check_output(cmd, text=True):
+        assert cmd == ["discover_hosts", "192.168.0.0/24"]
+        # Pretend that the command discovered two hosts.
+        return "192.168.0.10\n192.168.0.20\n"
+
+    monkeypatch.setattr(subprocess, "check_output", fake_check_output)
+
+    class DummySocket:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def settimeout(self, timeout):
+            pass
+
+        def connect(self, addr):
+            ip, _ = addr
+            # Simulate that only the first IP responds.
+            if ip != "192.168.0.10":
+                raise OSError("unreachable")
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(socket, "socket", lambda *a, **kw: DummySocket())
+
     result = discover_hosts("192.168.0.0/24")
-    assert isinstance(result, list)
+    assert result == ["192.168.0.10"]


### PR DESCRIPTION
## Summary
- add `_verify_host` helper and use external command output in `discover_hosts`
- monkeypatch subprocess and socket in tests for deterministic host discovery

## Testing
- `pytest tests/test_discover_hosts.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689c2dd28be08323a6c628938fced009