### PR TITLE
Improve dynamic scan API docs and critical alert handling

### DIFF
--- a/nw_checker/lib/dynamic_scan_tab.dart
+++ b/nw_checker/lib/dynamic_scan_tab.dart
@@ -56,6 +56,7 @@ class _DynamicScanTabState extends State<DynamicScanTab> {
               showDialog(
                 context: context,
                 builder: (_) => AlertDialog(
+                  key: const Key('criticalAlertDialog'),
                   title: const Text('Critical Alert'),
                   content: Text(msg),
                   actions: [

--- a/nw_checker/test/dynamic_scan_tab_test.dart
+++ b/nw_checker/test/dynamic_scan_tab_test.dart
@@ -106,4 +106,18 @@ void main() {
 
     // navigation to detail page is handled elsewhere
   });
+
+  testWidgets('shows dialog on critical alert', (tester) async {
+    await tester.pumpWidget(_buildWidget());
+
+    await tester.tap(find.text('スキャン開始'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+    // wait for second alert which is critical
+    await tester.pump(const Duration(seconds: 4));
+    await tester.pump();
+
+    expect(find.text('Critical Alert'), findsOneWidget);
+    expect(find.text('CRITICAL: Malware detected'), findsOneWidget);
+  });
 }

--- a/src/api.py
+++ b/src/api.py
@@ -66,16 +66,22 @@ async def stop_scan():
     return {"status": "stopped"}
 
 
-# 新形式のエンドポイントへのエイリアス
+# 新形式のエンドポイント (/dynamic-scan/*) へのエイリアス
 @app.post("/dynamic-scan/start")
 async def start_scan_v2(params: StartParams):
-    """動的スキャン開始エイリアス"""
+    """動的スキャン開始エイリアス
+
+    旧エンドポイント `/scan/dynamic/start` と同様にスケジュール登録を行う。
+    """
     return await start_scan(params)
 
 
 @app.post("/dynamic-scan/stop")
 async def stop_scan_v2():
-    """動的スキャン停止エイリアス"""
+    """動的スキャン停止エイリアス
+
+    旧エンドポイント `/scan/dynamic/stop` と同じ処理を実行する。
+    """
     return await stop_scan()
 
 
@@ -111,7 +117,10 @@ async def get_results():
 
 @app.get("/dynamic-scan/results")
 async def get_results_v2():
-    """動的スキャン結果取得エイリアス"""
+    """動的スキャン結果取得エイリアス
+
+    `/scan/dynamic/results` と同じ集計結果を返す。
+    """
     return await get_results()
 
 

--- a/tests/test_api_dynamic_scan_alias.py
+++ b/tests/test_api_dynamic_scan_alias.py
@@ -1,0 +1,21 @@
+import asyncio
+from fastapi.testclient import TestClient
+
+from src import api
+from src.dynamic_scan import scheduler, storage
+
+
+def test_dynamic_scan_results_alias(monkeypatch, tmp_path):
+    client = TestClient(api.app)
+    store = storage.Storage(tmp_path / "res.db")
+    api.scan_scheduler = scheduler.DynamicScanScheduler()
+    monkeypatch.setattr(storage, "Storage", lambda *args, **kwargs: store)
+
+    asyncio.run(api.scan_scheduler.storage.save_result({"protocol": "ftp"}))
+
+    resp_old = client.get("/scan/dynamic/results")
+    resp_new = client.get("/dynamic-scan/results")
+
+    assert resp_old.status_code == 200
+    assert resp_new.status_code == 200
+    assert resp_old.json() == resp_new.json()


### PR DESCRIPTION
## Summary
- document new `/dynamic-scan/*` API aliases in backend
- show critical alerts via keyed dialog in dynamic scan tab
- test that critical alerts trigger the dialog
- add backend test ensuring `/dynamic-scan/results` mirrors legacy endpoint

## Testing
- `pytest tests/test_api_dynamic_scan_alias.py`
- `flutter test test/dynamic_scan_tab_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_689c22d0579883238bbfbfb735b1adcc