### PR TITLE
chore: configure src path for tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 testpaths = tests
 python_files = test_*.py
+pythonpath = src

--- a/tests/integration/test_dynamic_scan_flow.py
+++ b/tests/integration/test_dynamic_scan_flow.py
@@ -1,13 +1,8 @@
 import asyncio
 import tracemalloc
 from contextlib import suppress
-import pathlib
-import sys
-
 import pytest
 from fastapi.testclient import TestClient
-
-sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
 
 from src import api
 from src.dynamic_scan import analyze, capture, storage


### PR DESCRIPTION
## Summary
- remove manual sys.path modification in dynamic scan integration test
- let pytest resolve `src` package via `pythonpath`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c3e579254832387c6785565e42ba7