### PR TITLE
Add benchmark marker to pytest configuration

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 testpaths = tests
 python_files = test_*.py
+markers = benchmark: performance benchmark


### PR DESCRIPTION
## Summary
- allow `benchmark` marker for performance tests in pytest

## Testing
- `pytest --strict-markers`


------
https://chatgpt.com/codex/tasks/task_e_689c3e54d8e4832381e017771c21085b