### PR TITLE
Handle missing DNS blacklist file

### DIFF
--- a/src/dynamic_scan/analyze.py
+++ b/src/dynamic_scan/analyze.py
@@ -13,13 +13,23 @@ import requests
 DANGEROUS_PROTOCOLS = {"telnet", "ftp", "rdp"}
 
 
-def load_blacklist(path: str = "data/dns_blacklist.txt") -> set[str]:
-    with open(path) as f:
-        return {
-            line.strip()
-            for line in f
-            if line.strip() and not line.startswith("#")
-        }
+def load_blacklist(path: Path | str | None = None) -> set[str]:
+    """ブラックリストファイルを読み込む"""
+
+    path = (
+        Path(path)
+        if path is not None
+        else Path(__file__).resolve().parents[2] / "data" / "dns_blacklist.txt"
+    )
+    try:
+        with path.open() as f:
+            return {
+                line.strip()
+                for line in f
+                if line.strip() and not line.startswith("#")
+            }
+    except FileNotFoundError:
+        return set()
 
 
 # DNS 逆引きのブラックリスト

--- a/tests/test_dynamic_scan_analyze.py
+++ b/tests/test_dynamic_scan_analyze.py
@@ -161,8 +161,7 @@ def test_load_blacklist(tmp_path):
 
 def test_load_blacklist_missing_file(tmp_path):
     missing = tmp_path / "no_such_file.txt"
-    with pytest.raises(FileNotFoundError):
-        analyze.load_blacklist(missing)
+    assert analyze.load_blacklist(missing) == set()
 
 
 def test_load_blacklist_default_file():


### PR DESCRIPTION
## Summary
- compute DNS blacklist path relative to module
- return empty set when blacklist file is missing
- adjust tests for new blacklist loader behavior

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c3e35634c8323aba3c39b4c38066d