### PR TITLE
Add DNS blacklist updater with feed fetching and CLI

### DIFF
--- a/src/dynamic_scan/__init__.py
+++ b/src/dynamic_scan/__init__.py
@@ -1,0 +1,5 @@
+# Dynamic scan utilities
+
+from .blacklist_updater import fetch_feed, write_blacklist
+
+__all__ = ["fetch_feed", "write_blacklist"]

--- a/src/dynamic_scan/blacklist_updater.py
+++ b/src/dynamic_scan/blacklist_updater.py
@@ -1,0 +1,97 @@
+import argparse
+import csv
+import json
+import logging
+import os
+from io import StringIO
+from typing import Iterable, Set
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+def fetch_feed(url: str) -> Set[str]:
+    """Fetch a blacklist feed from a URL or local file and return domains."""
+    try:
+        if url.startswith("file://") or os.path.exists(url):
+            path = url[7:] if url.startswith("file://") else url
+            with open(path, "r", encoding="utf-8") as f:
+                text = f.read()
+            content_type = "text/plain"
+        else:
+            resp = requests.get(url, timeout=10)
+            resp.raise_for_status()
+            content_type = resp.headers.get("Content-Type", "")
+            text = resp.text
+    except Exception as exc:
+        logger.error("failed to fetch %s: %s", url, exc)
+        return set()
+
+    try:
+        if "json" in content_type or url.endswith(".json"):
+            data = json.loads(text)
+            if isinstance(data, dict):
+                domains = data.get("domains") or data.get("blacklist") or []
+            elif isinstance(data, list):
+                domains = data
+            else:
+                domains = []
+        else:
+            domains = []
+            reader = csv.reader(StringIO(text))
+            for row in reader:
+                if row:
+                    domains.append(row[0].strip())
+    except Exception as exc:
+        logger.error("failed to parse feed %s: %s", url, exc)
+        return set()
+
+    return {d for d in (dom.strip() for dom in domains) if d and not d.startswith("#")}
+
+
+def write_blacklist(domains: Set[str], path: str = "data/dns_blacklist.txt") -> None:
+    """Write domains to blacklist file, keeping existing entries."""
+    if not domains:
+        logger.info("no domains fetched; skipping update")
+        return
+
+    tmp_path = f"{path}.tmp"
+
+    try:
+        existing: Set[str] = set()
+        if os.path.exists(path):
+            with open(path, "r", encoding="utf-8") as f:
+                existing = {line.strip() for line in f if line.strip() and not line.startswith("#")}
+
+        combined = existing | domains
+
+        with open(tmp_path, "w", encoding="utf-8") as f:
+            f.write("# DNS blacklist\n")
+            for domain in sorted(combined):
+                f.write(domain + "\n")
+
+        os.replace(tmp_path, path)
+    except Exception as exc:
+        logger.error("failed to write blacklist: %s", exc)
+        if os.path.exists(tmp_path):
+            os.remove(tmp_path)
+        raise
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Update DNS blacklist from feeds")
+    parser.add_argument("feeds", nargs="+", help="Feed URLs (CSV or JSON)")
+    parser.add_argument("--output", default="data/dns_blacklist.txt", help="Blacklist file path")
+    args = parser.parse_args(argv)
+
+    all_domains: Set[str] = set()
+    for url in args.feeds:
+        all_domains |= fetch_feed(url)
+
+    write_blacklist(all_domains, args.output)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    logging.basicConfig(level=logging.INFO)
+    main()

--- a/src/scans/dns.py
+++ b/src/scans/dns.py
@@ -35,7 +35,7 @@ def _get_nameservers(path: str = "/etc/resolv.conf") -> List[str]:
 def _is_private(ip: str) -> bool:
     try:
         addr = ip_address(ip)
-        return any(addr in net for net in _PRIVATE_NETS)
+        return addr.is_private or addr.is_loopback
     except ValueError:
         return False
 
@@ -53,7 +53,7 @@ def scan() -> dict:
         warnings.append("外部DNSが検出されました: " + ", ".join(external))
         details["external_servers"] = external
 
-    dnssec_enabled = False
+    dnssec_enabled: bool | None = None
     try:
         pkt = (
             IP(dst=servers[0])
@@ -67,7 +67,7 @@ def scan() -> dict:
         details["error"] = str(exc)
 
     details["dnssec_enabled"] = dnssec_enabled
-    if not dnssec_enabled:
+    if dnssec_enabled is False:
         warnings.append("DNSSECが無効です")
 
     details["warnings"] = warnings

--- a/tests/test_blacklist_updater.py
+++ b/tests/test_blacklist_updater.py
@@ -1,0 +1,56 @@
+import requests
+from src.dynamic_scan.blacklist_updater import fetch_feed, write_blacklist, main
+
+
+def test_fetch_feed_json(monkeypatch):
+    class Resp:
+        def __init__(self):
+            self.text = '{"domains": ["a.com", "b.org"]}'
+            self.headers = {"Content-Type": "application/json"}
+
+        def raise_for_status(self):
+            pass
+
+    monkeypatch.setattr(requests, "get", lambda url, timeout: Resp())
+    assert fetch_feed("http://example.com/feed.json") == {"a.com", "b.org"}
+
+
+def test_write_blacklist(tmp_path):
+    path = tmp_path / "dns_blacklist.txt"
+    path.write_text("# header\nold.com\n")
+    write_blacklist({"new.com"}, path=str(path))
+    content = path.read_text().splitlines()
+    assert "old.com" in content
+    assert "new.com" in content
+
+def test_fetch_feed_csv(monkeypatch):
+    class Resp:
+        def __init__(self):
+            self.text = "c.com\n#comment\nd.org"
+            self.headers = {"Content-Type": "text/csv"}
+
+        def raise_for_status(self):
+            pass
+
+    monkeypatch.setattr(requests, "get", lambda url, timeout: Resp())
+    assert fetch_feed("http://example.com/feed.csv") == {"c.com", "d.org"}
+
+
+def test_fetch_feed_file(tmp_path):
+    p = tmp_path / "feed.txt"
+    p.write_text("e.com\nf.org\n")
+    assert fetch_feed(str(p)) == {"e.com", "f.org"}
+
+
+def test_main_updates_blacklist(tmp_path):
+    feed1 = tmp_path / "feed1.csv"
+    feed1.write_text("a.com\n")
+    feed2 = tmp_path / "feed2.json"
+    feed2.write_text("[\"b.org\"]")
+
+    out = tmp_path / "dns_blacklist.txt"
+    main([str(feed1), str(feed2), "--output", str(out)])
+
+    lines = out.read_text().splitlines()
+    assert "a.com" in lines
+    assert "b.org" in lines


### PR DESCRIPTION
## Summary
- add `blacklist_updater` module to fetch CSV/JSON or local file feeds and update DNS blacklist
- ensure safe file writes with logging & error handling
- provide CLI entry point and tests
- handle DNS scan errors without flagging loopback servers or DNSSEC warnings
- add tests for CLI updating and loopback DNS handling

## Testing
- `pytest tests/test_blacklist_updater.py -q`
- `pytest tests/test_scan_modules.py::test_dns_scan_handles_error tests/test_scan_modules.py::test_dns_scan_ignores_loopback_nameserver -vv`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'geoip2'; fixture 'benchmark' not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bd03c08008323a12aebbc96a8f1e6