### PR TITLE
Load DNS blacklist from file

### DIFF
--- a/data/dns_blacklist.txt
+++ b/data/dns_blacklist.txt
@@ -2,3 +2,4 @@
 malicious.example
 phishing.test
 botnet.example.org
+spyware.example.net

--- a/src/dynamic_scan/analyze.py
+++ b/src/dynamic_scan/analyze.py
@@ -13,23 +13,15 @@ import httpx
 DANGEROUS_PROTOCOLS = {"telnet", "ftp", "rdp"}
 
 
-def load_blacklist(path: Path | str | None = None) -> set[str]:
+def load_blacklist(path: str = "data/dns_blacklist.txt") -> set[str]:
     """ブラックリストファイルを読み込む"""
 
-    path = (
-        Path(path)
-        if path is not None
-        else Path(__file__).resolve().parents[2] / "data" / "dns_blacklist.txt"
-    )
-    try:
-        with path.open() as f:
-            return {
-                line.strip()
-                for line in f
-                if line.strip() and not line.startswith("#")
-            }
-    except FileNotFoundError:
-        return set()
+    with open(path, encoding="utf-8") as f:
+        return {
+            line.strip()
+            for line in f
+            if line.strip() and not line.startswith("#")
+        }
 
 
 # DNS 逆引きのブラックリスト

--- a/tests/test_dynamic_scan_analyze.py
+++ b/tests/test_dynamic_scan_analyze.py
@@ -216,7 +216,8 @@ def test_load_blacklist(tmp_path):
 
 def test_load_blacklist_missing_file(tmp_path):
     missing = tmp_path / "no_such_file.txt"
-    assert analyze.load_blacklist(missing) == set()
+    with pytest.raises(FileNotFoundError):
+        analyze.load_blacklist(missing)
 
 
 def test_load_blacklist_default_file():


### PR DESCRIPTION
## Summary
- add DNS blacklist domain list under data/
- replace hard-coded DNS_BLACKLIST with file-driven loader
- adjust tests for new blacklist loader

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e9cf6d5dc83239abb8813f0156e0f