### PR TITLE
Add blacklist updater utility and tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ geoip2==5.1.0
 pytest==8.4.1
 fastapi==0.116.1
 httpx==0.28.1
+requests==2.32.3
 reportlab==4.4.3
 pypdf==5.9.0
 apscheduler==3.11.0

--- a/tests/test_blacklist_updater.py
+++ b/tests/test_blacklist_updater.py
@@ -1,134 +1,52 @@
-import asyncio
-import httpx
+import requests
 from src.dynamic_scan import analyze, blacklist_updater
 
 
-def test_fetch_feed_json(monkeypatch):
+def test_fetch_feed(monkeypatch):
     class Resp:
         def __init__(self):
-            self.text = '{"domains": ["a.com", "b.org"]}'
-            self.headers = {"Content-Type": "application/json"}
+            self.text = "a.com\n#comment\nb.org"
+            self.headers = {"Content-Type": "text/plain"}
 
         def raise_for_status(self):
             pass
 
-    class FakeClient:
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, exc_type, exc, tb):
-            pass
-
-        async def get(self, url):
-            return Resp()
-
-    monkeypatch.setattr(blacklist_updater.httpx, "AsyncClient", lambda *a, **k: FakeClient())
-    assert asyncio.run(blacklist_updater.fetch_feed("http://example.com/feed.json")) == {"a.com", "b.org"}
+    monkeypatch.setattr(requests, "get", lambda url, timeout=10: Resp())
+    assert blacklist_updater.fetch_feed("http://example.com/feed") == {"a.com", "b.org"}
 
 
-def test_fetch_feed_json_list(monkeypatch):
-    class Resp:
-        def __init__(self):
-            self.text = '["c.com", "d.org"]'
-            self.headers = {"Content-Type": "application/json"}
-
-        def raise_for_status(self):
-            pass
-
-    class FakeClient:
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, exc_type, exc, tb):
-            pass
-
-        async def get(self, url):
-            return Resp()
-
-    monkeypatch.setattr(blacklist_updater.httpx, "AsyncClient", lambda *a, **k: FakeClient())
-    assert asyncio.run(blacklist_updater.fetch_feed("http://example.com/list.json")) == {"c.com", "d.org"}
-
-
-def test_write_blacklist(tmp_path):
+def test_merge_blacklist(tmp_path):
     path = tmp_path / "dns_blacklist.txt"
     path.write_text("# header\nold.com\n")
-    blacklist_updater.write_blacklist({"new.com"}, path=str(path))
+    blacklist_updater.merge_blacklist({"new.com"}, path=str(path))
     content = path.read_text().splitlines()
     assert "old.com" in content
     assert "new.com" in content
 
-def test_fetch_feed_csv(monkeypatch):
-    class Resp:
-        def __init__(self):
-            self.text = "c.com\n#comment\nd.org"
-            self.headers = {"Content-Type": "text/csv"}
 
-        def raise_for_status(self):
-            pass
+def test_merge_blacklist_error(tmp_path, monkeypatch):
+    path = tmp_path / "dns_blacklist.txt"
+    path.write_text("original.com\n")
 
-    class FakeClient:
-        async def __aenter__(self):
-            return self
+    def fail_replace(src, dst):
+        raise OSError("boom")
 
-        async def __aexit__(self, exc_type, exc, tb):
-            pass
+    monkeypatch.setattr(blacklist_updater.os, "replace", fail_replace)
+    try:
+        blacklist_updater.merge_blacklist({"new.com"}, path=str(path))
+    except OSError:
+        pass
+    assert path.read_text() == "original.com\n"
 
-        async def get(self, url):
-            return Resp()
 
-    monkeypatch.setattr(blacklist_updater.httpx, "AsyncClient", lambda *a, **k: FakeClient())
-    assert asyncio.run(blacklist_updater.fetch_feed("http://example.com/feed.csv")) == {"c.com", "d.org"}
+def test_update_integration(tmp_path, monkeypatch):
+    monkeypatch.setattr(blacklist_updater, "fetch_feed", lambda url: {"x.com"})
+    out = tmp_path / "out.txt"
+    blacklist_updater.update("http://feed", path=str(out))
+    assert "x.com" in out.read_text()
 
 
 def test_load_blacklist(tmp_path):
     blk = tmp_path / "dns_blacklist.txt"
     blk.write_text("# comment\nfoo.example\nbar.example\n")
     assert analyze.load_blacklist(str(blk)) == {"foo.example", "bar.example"}
-
-
-def test_update_integration(monkeypatch, tmp_path):
-    class Resp:
-        def __init__(self):
-            self.text = "x.com\n#c\ny.org"
-            self.headers = {"Content-Type": "text/plain"}
-
-        def raise_for_status(self):
-            pass
-
-    class FakeClient:
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, exc_type, exc, tb):
-            pass
-
-        async def get(self, url):
-            return Resp()
-
-    monkeypatch.setattr(blacklist_updater.httpx, "AsyncClient", lambda *a, **k: FakeClient())
-    out = tmp_path / "out.txt"
-    blacklist_updater.update("http://feed", output_path=str(out))
-    lines = out.read_text().splitlines()
-    assert "x.com" in lines and "y.org" in lines
-    assert lines[0].startswith("#")
-
-
-def test_fetch_feed_error(monkeypatch):
-    class FailClient:
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, exc_type, exc, tb):
-            pass
-
-        async def get(self, url):  # pragma: no cover - 例外発生の確認用
-            raise httpx.RequestError("boom")
-
-    monkeypatch.setattr(blacklist_updater.httpx, "AsyncClient", lambda *a, **k: FailClient())
-    assert asyncio.run(blacklist_updater.fetch_feed("http://example.com/feed")) == set()
-
-
-def test_write_blacklist_no_domains(tmp_path):
-    path = tmp_path / "dns_blacklist.txt"
-    blacklist_updater.write_blacklist(set(), path=str(path))
-    assert not path.exists()


### PR DESCRIPTION
## Summary
- add requests-based feed downloader and atomic blacklist merge with logging
- expose CLI entry for manual DNS blacklist updates
- cover blacklist updater with unit tests

## Testing
- `./setup.sh`
- `PYTHONPATH=. pytest`
- `sh flutter_env.sh` *(fails: Expected to find project root in current working directory.)*

------
https://chatgpt.com/codex/tasks/task_e_689e9cf7b8c88323aeca9258ddea0bbe