### PR TITLE
Schedule blacklist updater job with explicit triggers

### DIFF
--- a/src/dynamic_scan/scheduler.py
+++ b/src/dynamic_scan/scheduler.py
@@ -87,7 +87,7 @@ class DynamicScanScheduler:
         # APScheduler でコルーチンを定期実行
         self.job = self.scheduler.add_job(
             self._run_scan,
-            "interval",
+            trigger="interval",
             seconds=interval,
             args=[interface, duration, approved_macs],
             max_instances=1,
@@ -96,7 +96,7 @@ class DynamicScanScheduler:
         if feed_url:
             self.blacklist_job = self.scheduler.add_job(
                 blacklist_updater.update,
-                "interval",
+                trigger="interval",
                 hours=interval_hours,
                 args=[feed_url],
             )


### PR DESCRIPTION
## Summary
- use explicit `trigger="interval"` for scheduled scan and blacklist update jobs
- keep blacklist updater registered when `BLACKLIST_FEED_URL` is configured

## Testing
- `PYTHONPATH=. pytest -q`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_689e9cf8ccfc83238385931739f59292