### PR TITLE
Add network map module and tests

### DIFF
--- a/src/network_map.py
+++ b/src/network_map.py
@@ -1,0 +1,38 @@
+"""Network mapping utilities."""
+
+import argparse
+import json
+import sys
+
+from .discover_hosts import discover_hosts
+
+
+def network_map(subnet: str):
+    """Return a list of reachable hosts in *subnet*.
+
+    This function is a thin wrapper around :func:`discover_hosts` to allow
+    for straightforward unit testing and potential future extensions.
+    """
+
+    return discover_hosts(subnet)
+
+
+def main(argv=None):
+    """CLI entry point for building a network map."""
+
+    parser = argparse.ArgumentParser(description="Scan a subnet for hosts")
+    parser.add_argument("subnet", help="CIDR subnet to scan")
+    args = parser.parse_args(argv)
+    try:
+        hosts = network_map(args.subnet)
+    except Exception as exc:
+        print(f"Host discovery failed: {exc}", file=sys.stderr)
+        return 1
+    json.dump(hosts, sys.stdout)
+    sys.stdout.write("\n")
+    print("Host discovery succeeded", file=sys.stdout)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_network_map.py
+++ b/tests/test_network_map.py
@@ -1,0 +1,34 @@
+"""Tests for :mod:`network_map`."""
+
+import json
+
+import pytest
+
+from src import network_map
+
+
+def test_network_map_success(monkeypatch, capsys):
+    """JSON output and success log are emitted on success."""
+
+    monkeypatch.setattr(network_map, "discover_hosts", lambda subnet: ["192.168.0.10"])
+    exit_code = network_map.main(["192.168.0.0/24"])
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    out_lines = captured.out.strip().splitlines()
+    assert json.loads(out_lines[0]) == ["192.168.0.10"]
+    assert "succeeded" in out_lines[1]
+    assert captured.err == ""
+
+
+def test_network_map_failure(monkeypatch, capsys):
+    """Errors are reported to stderr and non-zero exit code is returned."""
+
+    def boom(subnet):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(network_map, "discover_hosts", boom)
+    exit_code = network_map.main(["192.168.0.0/24"])
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert captured.out == ""
+    assert "boom" in captured.err

--- a/tests/test_network_map.py
+++ b/tests/test_network_map.py
@@ -7,6 +7,21 @@ import pytest
 from src import network_map
 
 
+def test_network_map_delegates(monkeypatch):
+    """network_map() delegates to discover_hosts."""
+
+    calls = {}
+
+    def fake_discover(subnet):
+        calls["subnet"] = subnet
+        return ["10.0.0.1"]
+
+    monkeypatch.setattr(network_map, "discover_hosts", fake_discover)
+    result = network_map.network_map("10.0.0.0/24")
+    assert result == ["10.0.0.1"]
+    assert calls["subnet"] == "10.0.0.0/24"
+
+
 def test_network_map_success(monkeypatch, capsys):
     """JSON output and success log are emitted on success."""
 

--- a/tests/test_network_map.py
+++ b/tests/test_network_map.py
@@ -47,3 +47,14 @@ def test_network_map_failure(monkeypatch, capsys):
     assert exit_code == 1
     assert captured.out == ""
     assert "boom" in captured.err
+
+
+def test_main_requires_subnet_arg(capsys):
+    """Missing subnet argument triggers usage message and exit code 2."""
+
+    with pytest.raises(SystemExit) as exc:
+        network_map.main([])
+    captured = capsys.readouterr()
+    assert exc.value.code == 2
+    assert captured.out == ""
+    assert "usage" in captured.err.lower()


### PR DESCRIPTION
## Summary
- add `network_map` module that wraps `discover_hosts` and outputs JSON with logging
- test successful and failing execution paths for `network_map`

## Testing
- `pytest tests/test_network_map.py tests/test_discover_hosts.py`

------
https://chatgpt.com/codex/tasks/task_e_689eaddfa0f48323a4e96e8adb7bb3cb