### PR TITLE
feat: generate topology graphs with node labels

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ pypdf==5.9.0
 apscheduler==3.11.0
 pytest-benchmark==5.1.0
 impacket==0.11.0 ; sys_platform != "win32"
+graphviz==0.21

--- a/src/NWCD/generate_topology.py
+++ b/src/NWCD/generate_topology.py
@@ -1,0 +1,43 @@
+"""Utilities for generating network topology graphs."""
+from __future__ import annotations
+
+from typing import Dict, Iterable, List, Mapping, Sequence
+
+from graphviz import Digraph
+
+
+def build_graph(paths: Iterable[Sequence[str]], nodes: Mapping[str, Mapping[str, str]]) -> Digraph:
+    """Build a Graphviz digraph representing the topology.
+
+    Parameters
+    ----------
+    paths:
+        各経路を示すノードIDのリスト。
+    nodes:
+        ノードIDをキーとし、``hostname`` と ``vendor`` を含む辞書。
+
+    Returns
+    -------
+    graphviz.Digraph
+        生成されたグラフ。
+    """
+    graph = Digraph(format="svg")
+    # Flutter 側のタップ処理のためノード形状は楕円とする
+    graph.attr("node", shape="ellipse")
+
+    added: set[str] = set()
+
+    for path in paths:
+        for idx, node_id in enumerate(path):
+            info = nodes.get(node_id, {})
+            if node_id not in added:
+                hostname = info.get("hostname", "")
+                vendor = info.get("vendor", "")
+                label_parts: List[str] = [p for p in (hostname, vendor) if p]
+                label = "\n".join(label_parts) if label_parts else node_id
+                graph.node(node_id, label=label)
+                added.add(node_id)
+            if idx > 0:
+                parent = path[idx - 1]
+                graph.edge(parent, node_id)
+    return graph

--- a/tests/test_generate_topology.py
+++ b/tests/test_generate_topology.py
@@ -1,0 +1,28 @@
+from src.NWCD.generate_topology import build_graph
+
+
+def test_build_graph_hierarchy():
+    paths = [
+        ["1", "2", "3"],
+        ["1", "2", "4"],
+        ["1", "5"],
+    ]
+    nodes = {
+        "1": {"hostname": "root", "vendor": "Cisco"},
+        "2": {"hostname": "sw1", "vendor": "Juniper"},
+        "3": {"hostname": "hostA", "vendor": "Dell"},
+        "4": {"hostname": "hostB", "vendor": "HP"},
+        "5": {"hostname": "sw2", "vendor": "Cisco"},
+    }
+
+    graph = build_graph(paths, nodes)
+    src = graph.source
+
+    assert 'node [shape=ellipse]' in src
+    assert '1 -> 2' in src
+    assert '2 -> 3' in src
+    assert '2 -> 4' in src
+    assert '1 -> 5' in src
+
+    assert '1 [label="root\nCisco"]' in src
+    assert '3 [label="hostA\nDell"]' in src

--- a/tests/test_generate_topology.py
+++ b/tests/test_generate_topology.py
@@ -26,3 +26,17 @@ def test_build_graph_hierarchy():
 
     assert '1 [label="root\nCisco"]' in src
     assert '3 [label="hostA\nDell"]' in src
+
+
+def test_build_graph_label_fallback():
+    paths = [["A", "B"]]
+    nodes = {
+        "A": {"hostname": "alpha"},
+        "B": {},
+    }
+
+    graph = build_graph(paths, nodes)
+    src = graph.source
+
+    assert 'A [label=alpha]' in src
+    assert 'B [label=B]' in src


### PR DESCRIPTION
## Summary
- build Graphviz topology graphs from paths with hostname/vendor labels
- keep ellipse node shape for SVG tap detection
- add hierarchical topology test and graphviz dependency

## Testing
- `pytest tests/test_generate_topology.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689eae281dc083239d24d0041ed351e1