### PR TITLE
feat: add dynamic scan websocket alias

### DIFF
--- a/nw_checker/lib/services/dynamic_scan_api.dart
+++ b/nw_checker/lib/services/dynamic_scan_api.dart
@@ -106,6 +106,7 @@ class DynamicScanApi {
 
   /// アラート通知を購読する。
   /// 現状は2秒毎に2件のダミーアラートを流す。
+  /// 実装済みの `/ws/dynamic-scan` WebSocket が利用可能になれば置き換え予定。
   static Stream<String> subscribeAlerts() {
     return Stream.periodic(const Duration(seconds: 2), (count) {
       if (count == 0) {

--- a/src/api.py
+++ b/src/api.py
@@ -148,6 +148,7 @@ async def get_history_v2(
 
 
 @app.websocket("/ws/scan/dynamic")
+@app.websocket("/ws/dynamic-scan")
 async def ws_dynamic_scan(websocket: WebSocket):
     await websocket.accept()
     queue: asyncio.Queue = asyncio.Queue()

--- a/tests/test_api_dynamic_scan_alias.py
+++ b/tests/test_api_dynamic_scan_alias.py
@@ -19,3 +19,21 @@ def test_dynamic_scan_results_alias(monkeypatch, tmp_path):
     assert resp_old.status_code == 200
     assert resp_new.status_code == 200
     assert resp_old.json() == resp_new.json()
+
+
+def test_dynamic_scan_ws_alias(monkeypatch):
+    client = TestClient(api.app)
+    holder: dict[str, asyncio.Queue] = {}
+
+    def add_listener(queue):
+        holder["q"] = queue
+
+    def remove_listener(queue):
+        pass
+
+    monkeypatch.setattr(api.scan_scheduler.storage, "add_listener", add_listener)
+    monkeypatch.setattr(api.scan_scheduler.storage, "remove_listener", remove_listener)
+
+    with client.websocket_connect("/ws/dynamic-scan") as ws:
+        holder["q"].put_nowait({"foo": "bar"})
+        assert ws.receive_json() == {"foo": "bar"}


### PR DESCRIPTION
## Summary
- expose `/ws/dynamic-scan` alias for dynamic scan websocket
- document future websocket use in dynamic scan API client
- test websocket alias routing

## Testing
- `PYTHONPATH=. pytest`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_689eadc490a883238b857dc2ea420281