### PR TITLE
Add hostname resolution to discover_hosts

### DIFF
--- a/src/discover_hosts.py
+++ b/src/discover_hosts.py
@@ -2,6 +2,7 @@
 
 import socket
 import subprocess
+from typing import Dict, List, Optional
 
 
 def _verify_host(ip: str, port: int = 80, timeout: float = 0.1) -> bool:
@@ -22,21 +23,80 @@ def _verify_host(ip: str, port: int = 80, timeout: float = 0.1) -> bool:
         sock.close()
 
 
-def discover_hosts(subnet: str):
-    """Discover devices in the given subnet.
+def _run_nmap_scan(subnet: str) -> List[Dict[str, Optional[str]]]:
+    """Run an nmap scan and return discovered hosts.
 
-    The current implementation delegates the heavy lifting to an external
-    command that lists candidate hosts (one IP address per line).  Each
-    candidate is probed via :func:`_verify_host` to confirm that it is
-    reachable.
-
-    Returns:
-        list of IP addresses for hosts that responded.
+    Each host is represented as a dict with ``ip`` and optional ``hostname``
+    fields.  The ``-R`` option forces reverse DNS resolution so that nmap tries
+    to determine hostnames for all targets.
     """
     try:
-        output = subprocess.check_output(["discover_hosts", subnet], text=True)
+        output = subprocess.check_output(
+            ["nmap", "-sn", "-oG", "-", "-R", subnet], text=True
+        )
     except (OSError, subprocess.CalledProcessError):
         return []
 
-    candidates = [line.strip() for line in output.splitlines() if line.strip()]
-    return [ip for ip in candidates if _verify_host(ip)]
+    hosts: List[Dict[str, Optional[str]]] = []
+    for line in output.splitlines():
+        line = line.strip()
+        if not line.startswith("Host:"):
+            continue
+        # Example line: "Host: 192.168.0.1 (router)\tStatus: Up"
+        parts = line.split()
+        ip = parts[1]
+        hostname: Optional[str] = None
+        if len(parts) > 2 and parts[2].startswith("("):
+            hostname = parts[2].strip("()")
+        hosts.append({"ip": ip, "hostname": hostname})
+    return hosts
+
+
+def _get_hostname_nbtscan(ip: str) -> Optional[str]:
+    """Try to resolve hostname using nbtscan."""
+    try:
+        output = subprocess.check_output(["nbtscan", "-q", ip], text=True)
+    except (OSError, subprocess.CalledProcessError):
+        return None
+
+    for line in output.splitlines():
+        parts = line.strip().split()
+        if len(parts) >= 2 and parts[0] == ip:
+            return parts[1]
+    return None
+
+
+def _get_hostname_avahi(ip: str) -> Optional[str]:
+    """Try to resolve hostname using avahi-resolve."""
+    try:
+        output = subprocess.check_output(["avahi-resolve", "-a", ip], text=True)
+    except (OSError, subprocess.CalledProcessError):
+        return None
+
+    for line in output.splitlines():
+        parts = line.strip().split()
+        if len(parts) >= 2 and parts[0] == ip:
+            return parts[1]
+    return None
+
+
+def discover_hosts(subnet: str) -> List[Dict[str, str]]:
+    """Discover devices in the given subnet.
+
+    The current implementation delegates the heavy lifting to ``nmap`` to obtain
+    a list of candidate hosts.  Each candidate is probed via
+    :func:`_verify_host` to confirm reachability.  If ``nmap`` did not provide a
+    hostname, ``nbtscan`` or ``avahi-resolve`` is invoked to attempt name
+    resolution.
+    """
+    hosts = [h for h in _run_nmap_scan(subnet) if _verify_host(h["ip"]) ]
+
+    for host in hosts:
+        if host.get("hostname"):
+            continue
+        hostname = _get_hostname_nbtscan(host["ip"])
+        if not hostname:
+            hostname = _get_hostname_avahi(host["ip"])
+        if hostname:
+            host["hostname"] = hostname
+    return hosts

--- a/tests/test_discover_hosts.py
+++ b/tests/test_discover_hosts.py
@@ -6,13 +6,20 @@ import subprocess
 from src.discover_hosts import discover_hosts
 
 
-def test_discover_hosts_monkeypatched(monkeypatch):
-    """Ensure host discovery is independent from the external environment."""
+def test_discover_hosts_resolves_hostname(monkeypatch):
+    """Ensure host discovery and hostname resolution work."""
 
     def fake_check_output(cmd, text=True):
-        assert cmd == ["discover_hosts", "192.168.0.0/24"]
-        # Pretend that the command discovered two hosts.
-        return "192.168.0.10\n192.168.0.20\n"
+        if cmd[:2] == ["nmap", "-sn"]:
+            assert cmd == ["nmap", "-sn", "-oG", "-", "-R", "192.168.0.0/24"]
+            return (
+                "Host: 192.168.0.10 (printer) Status: Up\n"
+                "Host: 192.168.0.20 Status: Up\n"
+            )
+        if cmd[0] == "nbtscan":
+            assert cmd == ["nbtscan", "-q", "192.168.0.20"]
+            return "192.168.0.20 host20\n"
+        raise AssertionError(f"Unexpected command: {cmd}")
 
     monkeypatch.setattr(subprocess, "check_output", fake_check_output)
 
@@ -24,10 +31,7 @@ def test_discover_hosts_monkeypatched(monkeypatch):
             pass
 
         def connect(self, addr):
-            ip, _ = addr
-            # Simulate that only the first IP responds.
-            if ip != "192.168.0.10":
-                raise OSError("unreachable")
+            pass
 
         def close(self):
             pass
@@ -35,4 +39,49 @@ def test_discover_hosts_monkeypatched(monkeypatch):
     monkeypatch.setattr(socket, "socket", lambda *a, **kw: DummySocket())
 
     result = discover_hosts("192.168.0.0/24")
-    assert result == ["192.168.0.10"]
+    assert result == [
+        {"ip": "192.168.0.10", "hostname": "printer"},
+        {"ip": "192.168.0.20", "hostname": "host20"},
+    ]
+
+
+def test_discover_hosts_avahi_fallback(monkeypatch):
+    """Fallback to ``avahi-resolve`` when ``nbtscan`` fails."""
+
+    calls = []
+
+    def fake_check_output(cmd, text=True):
+        calls.append(cmd)
+        if cmd[:2] == ["nmap", "-sn"]:
+            assert cmd == ["nmap", "-sn", "-oG", "-", "-R", "192.168.0.0/24"]
+            return "Host: 192.168.0.30 Status: Up\n"
+        if cmd[0] == "nbtscan":
+            assert cmd == ["nbtscan", "-q", "192.168.0.30"]
+            raise subprocess.CalledProcessError(1, cmd)
+        if cmd[0] == "avahi-resolve":
+            assert cmd == ["avahi-resolve", "-a", "192.168.0.30"]
+            return "192.168.0.30 host30\n"
+        raise AssertionError(f"Unexpected command: {cmd}")
+
+    monkeypatch.setattr(subprocess, "check_output", fake_check_output)
+
+    class DummySocket:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def settimeout(self, timeout):
+            pass
+
+        def connect(self, addr):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(socket, "socket", lambda *a, **kw: DummySocket())
+
+    result = discover_hosts("192.168.0.0/24")
+    assert result == [{"ip": "192.168.0.30", "hostname": "host30"}]
+    # ensure nbtscan was tried before avahi-resolve
+    assert calls[1][0] == "nbtscan"
+    assert calls[2][0] == "avahi-resolve"


### PR DESCRIPTION
## Summary
- resolve hostnames by running `nmap -sn -R`
- fall back to `nbtscan`/`avahi-resolve` when `nmap` lacks names
- test hostname resolution and avahi fallback in `discover_hosts`

## Testing
- `PYTHONPATH=$PWD pytest -q`
- `cd nw_checker && flutter test`

------
https://chatgpt.com/codex/tasks/task_e_689eae1103508323aa040db604166e84