### PR TITLE
test: cover blacklist updater and analyze

### DIFF
--- a/tests/test_blacklist_updater.py
+++ b/tests/test_blacklist_updater.py
@@ -1,52 +1,55 @@
-import requests
 from src.dynamic_scan import analyze, blacklist_updater
 
 
-def test_fetch_feed(monkeypatch):
-    class Resp:
-        def __init__(self):
-            self.text = "a.com\n#comment\nb.org"
-            self.headers = {"Content-Type": "text/plain"}
+def test_load_blacklist_reads_domains(tmp_path):
+    blk = tmp_path / "dns_blacklist.txt"
+    blk.write_text("# comment\nfoo.example\nbar.example\n")
+    assert analyze.load_blacklist(str(blk)) == {"foo.example", "bar.example"}
+
+
+def test_merge_blacklist_deduplicates(tmp_path):
+    path = tmp_path / "dns_blacklist.txt"
+    path.write_text("old.com\n")
+    blacklist_updater.merge_blacklist({"old.com", "new.com"}, path=str(path))
+    lines = path.read_text().splitlines()
+    assert lines.count("old.com") == 1
+    assert "new.com" in lines
+
+
+def test_fetch_feed_parses_json(monkeypatch):
+    class FakeResp:
+        status_code = 200
+        headers = {"Content-Type": "application/json"}
 
         def raise_for_status(self):
             pass
 
-    monkeypatch.setattr(requests, "get", lambda url, timeout=10: Resp())
-    assert blacklist_updater.fetch_feed("http://example.com/feed") == {"a.com", "b.org"}
+        def json(self):
+            return {"domains": ["a.com", "b.com"]}
+
+    monkeypatch.setattr(blacklist_updater.requests, "get", lambda url, timeout=10: FakeResp())
+    assert blacklist_updater.fetch_feed("http://example.com/feed.json") == {"a.com", "b.com"}
 
 
-def test_merge_blacklist(tmp_path):
-    path = tmp_path / "dns_blacklist.txt"
-    path.write_text("# header\nold.com\n")
-    blacklist_updater.merge_blacklist({"new.com"}, path=str(path))
-    content = path.read_text().splitlines()
-    assert "old.com" in content
-    assert "new.com" in content
+def test_fetch_feed_parses_text(monkeypatch):
+    class FakeResp:
+        status_code = 200
+        headers = {"Content-Type": "text/plain"}
+        text = "#c\n d.com \n"
+
+        def raise_for_status(self):
+            pass
+
+    monkeypatch.setattr(blacklist_updater.requests, "get", lambda url, timeout=10: FakeResp())
+    assert blacklist_updater.fetch_feed("http://example.com/feed.txt") == {"d.com"}
 
 
-def test_merge_blacklist_error(tmp_path, monkeypatch):
-    path = tmp_path / "dns_blacklist.txt"
-    path.write_text("original.com\n")
-
-    def fail_replace(src, dst):
-        raise OSError("boom")
-
-    monkeypatch.setattr(blacklist_updater.os, "replace", fail_replace)
-    try:
-        blacklist_updater.merge_blacklist({"new.com"}, path=str(path))
-    except OSError:
-        pass
-    assert path.read_text() == "original.com\n"
-
-
-def test_update_integration(tmp_path, monkeypatch):
-    monkeypatch.setattr(blacklist_updater, "fetch_feed", lambda url: {"x.com"})
-    out = tmp_path / "out.txt"
-    blacklist_updater.update("http://feed", path=str(out))
-    assert "x.com" in out.read_text()
-
-
-def test_load_blacklist(tmp_path):
+def test_update_fetches_and_writes(monkeypatch, tmp_path):
     blk = tmp_path / "dns_blacklist.txt"
-    blk.write_text("# comment\nfoo.example\nbar.example\n")
-    assert analyze.load_blacklist(str(blk)) == {"foo.example", "bar.example"}
+    monkeypatch.setattr(
+        blacklist_updater,
+        "fetch_feed",
+        lambda url: {"foo.example"},
+    )
+    blacklist_updater.update("http://feed", path=str(blk))
+    assert "foo.example" in blk.read_text()


### PR DESCRIPTION
## Summary
- test load_blacklist reads domains from a temp file
- ensure merge_blacklist deduplicates existing domains
- exercise blacklist feed parsing and update writing

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689eae8bc54c8323a2b2810a397426c7