### PR TITLE
Add subnet-based topology builder and tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ pypdf==5.9.0
 apscheduler==3.11.0
 pytest-benchmark==5.1.0
 impacket==0.11.0 ; sys_platform != "win32"
+pysnmp==4.4.12

--- a/src/topology_builder.py
+++ b/src/topology_builder.py
@@ -1,0 +1,121 @@
+"""Network topology building utilities.
+
+This module constructs simple path representations between the local
+network and discovered hosts.  The implementation relies on the system's
+``traceroute`` command and optionally augments hop information using
+SNMP/LLDP queries via :mod:`pysnmp`.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from typing import Iterable, List
+
+from . import discover_hosts
+
+try:
+    from pysnmp.hlapi import (
+        CommunityData,
+        ContextData,
+        ObjectIdentity,
+        ObjectType,
+        SnmpEngine,
+        UdpTransportTarget,
+        nextCmd,
+    )
+except Exception:  # pragma: no cover - pysnmp may be unavailable
+    CommunityData = ContextData = ObjectIdentity = ObjectType = SnmpEngine = UdpTransportTarget = nextCmd = None
+
+
+LLDP_REMOTE_SYS_NAME_OID = "1.0.8802.1.1.2.1.4.1.1.9"
+
+
+def _run_traceroute(ip: str) -> str:
+    """Run ``traceroute`` and return its raw output."""
+    return subprocess.check_output(["traceroute", "-n", ip], text=True)
+
+
+def _parse_traceroute(output: str) -> List[str]:
+    """Parse traceroute output into a list of hop IP addresses."""
+    hops: List[str] = []
+    for line in output.splitlines():
+        line = line.strip()
+        if not line or line.startswith("traceroute"):
+            continue
+        parts = line.split()
+        if len(parts) >= 2 and parts[1] != "*":
+            hops.append(parts[1])
+    return hops
+
+
+def _get_lldp_neighbors(ip: str, community: str = "public") -> List[str]:
+    """Retrieve LLDP neighbor names using SNMP."""
+    if nextCmd is None:  # pysnmp not available
+        return []
+
+    neighbors: List[str] = []
+    try:
+        for (error_indication, error_status, _error_index, var_binds) in nextCmd(
+            SnmpEngine(),
+            CommunityData(community, mpModel=0),
+            UdpTransportTarget((ip, 161), timeout=1, retries=0),
+            ContextData(),
+            ObjectType(ObjectIdentity(LLDP_REMOTE_SYS_NAME_OID)),
+            lexicographicMode=False,
+        ):
+            if error_indication or error_status:
+                break
+            for var_bind in var_binds:
+                neighbors.append(str(var_bind[1]))
+    except Exception:
+        return []
+    return neighbors
+
+
+def build_topology(hosts: Iterable[str], use_snmp: bool = False, community: str = "public") -> str:
+    """Build topology paths for the given hosts.
+
+    Args:
+        hosts: Iterable of IP addresses discovered on the network.
+        use_snmp: Whether to complement hop information via SNMP/LLDP.
+        community: SNMP community string if ``use_snmp`` is ``True``.
+
+    Returns:
+        JSON string containing a ``paths`` array.
+    """
+    paths: List[List[str]] = []
+    for ip in hosts:
+        raw = _run_traceroute(ip)
+        hops = _parse_traceroute(raw)
+        path: List[str] = ["LAN"]
+        for hop in hops:
+            label = "Host" if hop == ip else "Router"
+            if use_snmp and hop != ip:
+                neighbors = _get_lldp_neighbors(hop, community)
+                if neighbors:
+                    # Use the first discovered neighbor name
+                    path.append(neighbors[0])
+                    continue
+            path.append(label)
+        paths.append(path)
+    return json.dumps({"paths": paths})
+
+
+def build_topology_for_subnet(subnet: str, use_snmp: bool = False, community: str = "public") -> str:
+    """Discover hosts in ``subnet`` and build topology paths.
+
+    This is a convenience wrapper around :func:`build_topology` that first
+    calls :func:`discover_hosts.discover_hosts` to obtain candidate hosts.
+
+    Args:
+        subnet: CIDR notation for the network to scan.
+        use_snmp: Whether to complement hop information via SNMP/LLDP.
+        community: SNMP community string if ``use_snmp`` is ``True``.
+
+    Returns:
+        JSON string containing a ``paths`` array, same as
+        :func:`build_topology`.
+    """
+    hosts = discover_hosts.discover_hosts(subnet)
+    return build_topology(hosts, use_snmp=use_snmp, community=community)

--- a/tests/test_topology_builder.py
+++ b/tests/test_topology_builder.py
@@ -1,0 +1,60 @@
+"""Tests for :mod:`topology_builder`."""
+
+import json
+
+from src.topology_builder import build_topology, build_topology_for_subnet
+
+
+def test_build_topology_basic(monkeypatch):
+    def fake_traceroute(ip):
+        return (
+            f"traceroute to {ip} ({ip}), 30 hops max\n"
+            "1  192.168.0.1  1.0 ms\n"
+            f"2  {ip}  2.0 ms\n"
+        )
+
+    monkeypatch.setattr("src.topology_builder._run_traceroute", lambda ip: fake_traceroute(ip))
+    monkeypatch.setattr("src.topology_builder._get_lldp_neighbors", lambda ip, community="public": [])
+
+    result = json.loads(build_topology(["192.168.0.10"]))
+    assert result == {"paths": [["LAN", "Router", "Host"]]}
+
+
+def test_build_topology_with_snmp(monkeypatch):
+    def fake_traceroute(ip):
+        return (
+            f"traceroute to {ip} ({ip}), 30 hops max\n"
+            "1  192.168.0.1  1.0 ms\n"
+            f"2  {ip}  2.0 ms\n"
+        )
+
+    def fake_neighbors(ip, community="public"):
+        return ["SwitchA"] if ip == "192.168.0.1" else []
+
+    monkeypatch.setattr("src.topology_builder._run_traceroute", lambda ip: fake_traceroute(ip))
+    monkeypatch.setattr("src.topology_builder._get_lldp_neighbors", fake_neighbors)
+
+    result = json.loads(build_topology(["192.168.0.20"], use_snmp=True))
+    assert result == {"paths": [["LAN", "SwitchA", "Host"]]}
+
+
+def test_build_topology_for_subnet(monkeypatch):
+    """`build_topology_for_subnet` uses discovery results."""
+
+    # Fake discovery returning two hosts
+    monkeypatch.setattr(
+        "src.topology_builder.discover_hosts.discover_hosts", lambda subnet: ["10.0.0.1", "10.0.0.2"]
+    )
+
+    def fake_traceroute(ip):
+        return (
+            f"traceroute to {ip} ({ip}), 30 hops max\n"
+            "1  192.168.0.1  1.0 ms\n"
+            f"2  {ip}  2.0 ms\n"
+        )
+
+    monkeypatch.setattr("src.topology_builder._run_traceroute", lambda ip: fake_traceroute(ip))
+    monkeypatch.setattr("src.topology_builder._get_lldp_neighbors", lambda ip, community="public": [])
+
+    result = json.loads(build_topology_for_subnet("192.168.0.0/24"))
+    assert result == {"paths": [["LAN", "Router", "Host"], ["LAN", "Router", "Host"]]}


### PR DESCRIPTION
## Summary
- provide build_topology_for_subnet convenience wrapper calling host discovery
- cover subnet-based building with new unit test

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest`
- `cd nw_checker && flutter test`


------
https://chatgpt.com/codex/tasks/task_e_689eadf4b92c8323b580ef378b596b19