### PR TITLE
refactor: remove redundant default branches

### DIFF
--- a/nw_checker/lib/static_scan_tab.dart
+++ b/nw_checker/lib/static_scan_tab.dart
@@ -245,7 +245,6 @@ class _StaticScanTabState extends State<StaticScanTab> {
       case ScanStatus.ok:
         return Colors.blueGrey;
       case ScanStatus.pending:
-      default:
         return Colors.grey;
     }
   }
@@ -259,7 +258,6 @@ class _StaticScanTabState extends State<StaticScanTab> {
       case ScanStatus.ok:
         return 'OK';
       case ScanStatus.pending:
-      default:
         return '未実行';
     }
   }


### PR DESCRIPTION
## Summary
- remove redundant default switch cases in StaticScanTab status helpers

## Testing
- `flutter analyze`
- `flutter test`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a01de642b48323952daf7c82b29cf3