### PR TITLE
refactor: remove redundant default branches

### DIFF
--- a/nw_checker/lib/static_scan_tab.dart
+++ b/nw_checker/lib/static_scan_tab.dart
@@ -245,7 +245,6 @@ class _StaticScanTabState extends State<StaticScanTab> {
       case ScanStatus.ok:
         return Colors.blueGrey;
       case ScanStatus.pending:
-      default:
         return Colors.grey;
     }
   }
@@ -259,7 +258,6 @@ class _StaticScanTabState extends State<StaticScanTab> {
       case ScanStatus.ok:
         return 'OK';
       case ScanStatus.pending:
-      default:
         return '未実行';
     }
   }

--- a/nw_checker/test/static_scan_status_helpers_test.dart
+++ b/nw_checker/test/static_scan_status_helpers_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nw_checker/static_scan_tab.dart';
+
+void main() {
+  testWidgets('chips reflect status colors and labels', (tester) async {
+    Future<Map<String, dynamic>> mockScan() async {
+      return {
+        'summary': [],
+        'findings': [
+          {
+            'category': 'ports',
+            'details': {'open_ports': []},
+          },
+          {
+            'category': 'os_banner',
+            'details': {'os': '', 'banners': {}},
+          },
+          {
+            'category': 'smb_netbios',
+            'details': {'smb1_enabled': true, 'netbios_names': []},
+          },
+        ],
+      };
+    }
+
+    await tester.pumpWidget(
+      MaterialApp(home: StaticScanTab(scanner: mockScan)),
+    );
+
+    final initialChip = tester.widget<Chip>(find.byType(Chip).first);
+    expect((initialChip.label as Text).data, '未実行');
+    expect(initialChip.backgroundColor, Colors.grey);
+
+    await tester.tap(find.byKey(const Key('staticButton')));
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    final portChip = tester.widget<Chip>(find.byType(Chip).at(0));
+    expect((portChip.label as Text).data, 'OK');
+    expect(portChip.backgroundColor, Colors.blueGrey);
+
+    final osChip = tester.widget<Chip>(find.byType(Chip).at(1));
+    expect((osChip.label as Text).data, 'エラー');
+    expect(osChip.backgroundColor, Colors.red);
+
+    final smbChip = tester.widget<Chip>(find.byType(Chip).at(2));
+    expect((smbChip.label as Text).data, '警告');
+    expect(smbChip.backgroundColor, Colors.orange);
+  });
+}


### PR DESCRIPTION
## Summary
- remove redundant default switch cases in StaticScanTab status helpers
- add tests verifying chip labels and colors for all ScanStatus values

## Testing
- `flutter analyze`
- `flutter test`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a01de642b48323952daf7c82b29cf3