### PR TITLE
Remove static scan summary card

### DIFF
--- a/nw_checker/lib/static_scan_tab.dart
+++ b/nw_checker/lib/static_scan_tab.dart
@@ -52,7 +52,6 @@ class StaticScanTab extends StatefulWidget {
 
 class _StaticScanTabState extends State<StaticScanTab> {
   bool _isLoading = false;
-  List<String> _summaryLines = [];
   late List<CategoryTile> _categories;
 
   @override
@@ -73,7 +72,6 @@ class _StaticScanTabState extends State<StaticScanTab> {
   void _startScan() {
     setState(() {
       _isLoading = true;
-      _summaryLines = [];
       for (final c in _categories) {
         c.status = ScanStatus.pending;
         c.details = [];
@@ -86,10 +84,6 @@ class _StaticScanTabState extends State<StaticScanTab> {
       if (!mounted) return;
       setState(() {
         _isLoading = false;
-        _summaryLines = List<String>.from(
-          result['summary'] as List? ?? const [],
-        );
-
         final findings =
             (result['findings'] as List?)?.cast<Map<String, dynamic>>() ?? [];
         final portsFinding = findings.firstWhere(
@@ -264,21 +258,6 @@ class _StaticScanTabState extends State<StaticScanTab> {
     }
   }
 
-  Widget _buildSummaryCard() {
-    final lines = _summaryLines.isEmpty ? ['スキャン未実施'] : _summaryLines;
-    return Card(
-      color: Colors.blueGrey[50],
-      margin: const EdgeInsets.all(8),
-      child: Padding(
-        padding: const EdgeInsets.all(8),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: lines.map((e) => Text(e)).toList(),
-        ),
-      ),
-    );
-  }
-
   Widget _buildCategoryList() {
     return ListView.builder(
       itemCount: _categories.length,
@@ -306,7 +285,6 @@ class _StaticScanTabState extends State<StaticScanTab> {
   Widget build(BuildContext context) {
     return Column(
       children: [
-        _buildSummaryCard(),
         ElevatedButton(
           key: const Key('staticButton'),
           style: ElevatedButton.styleFrom(backgroundColor: Colors.blueGrey),

--- a/nw_checker/test/static_scan_tab_flow_test.dart
+++ b/nw_checker/test/static_scan_tab_flow_test.dart
@@ -74,8 +74,7 @@ void main() {
   ) async {
     await tester.pumpWidget(buildWidget());
 
-    // Initial summary and status badges
-    expect(find.text('スキャン未実施'), findsOneWidget);
+    // Initial status badges
     expect(find.byType(ListView), findsOneWidget);
     final initialChips = tester.widgetList<Chip>(find.byType(Chip)).toList();
     expect(initialChips, hasLength(8));
@@ -88,8 +87,6 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byType(CircularProgressIndicator), findsNothing);
-    expect(find.text('=== STATIC SCAN REPORT ==='), findsOneWidget);
-    expect(find.text('No issues detected.'), findsOneWidget);
 
     // Category order
     final portDy = tester.getTopLeft(find.text('Port Scan')).dy;

--- a/nw_checker/test/widget_test.dart
+++ b/nw_checker/test/widget_test.dart
@@ -72,7 +72,7 @@ void main() {
 
     await tester.pump(const Duration(seconds: 1));
     await tester.pumpAndSettle();
-    expect(find.text('スキャン失敗'), findsOneWidget);
+    expect(find.byType(CircularProgressIndicator), findsNothing);
   });
 
   testWidgets('Dynamic scan tab runs and displays JSON', (


### PR DESCRIPTION
## Summary
- drop unused "scan not executed" summary card from static scan tab
- update tests to match simplified UI

## Testing
- `PYTHONPATH=. pytest`
- `cd nw_checker && flutter test`


------
https://chatgpt.com/codex/tasks/task_e_68a01b69ee108323bcc6fe0f6140da06