### PR TITLE
Enhance network diagram loading and theming

### DIFF
--- a/nw_checker/lib/main.dart
+++ b/nw_checker/lib/main.dart
@@ -17,7 +17,7 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         brightness: Brightness.dark,
         colorScheme: ColorScheme.fromSeed(
-          seedColor: Colors.teal,
+          seedColor: const Color(0xFF64FFDA),
           brightness: Brightness.dark,
         ),
       ),

--- a/nw_checker/lib/network_diagram_page.dart
+++ b/nw_checker/lib/network_diagram_page.dart
@@ -83,7 +83,19 @@ class _NetworkDiagramPageState extends State<NetworkDiagramPage> {
                           height: 40,
                           child: GestureDetector(
                             onTap: () => setState(() => _selected = node),
-                            child: Container(color: Colors.transparent),
+                            child: Container(
+                              decoration: BoxDecoration(
+                                color: Colors.transparent,
+                                border: _selected?['id'] == node['id']
+                                    ? Border.all(
+                                        color: Theme.of(
+                                          context,
+                                        ).colorScheme.secondary,
+                                        width: 2,
+                                      )
+                                    : null,
+                              ),
+                            ),
                           ),
                         ),
                     ],

--- a/nw_checker/lib/network_scan.dart
+++ b/nw_checker/lib/network_scan.dart
@@ -1,16 +1,52 @@
 import 'dart:convert';
 import 'package:flutter/services.dart' show rootBundle;
+import 'package:http/http.dart' as http;
 
 /// ネットワーク図データを読み込むユーティリティ。
 class NetworkScan {
+  static const _jsonUrl = 'http://localhost:8000/topology.json';
+  static const _svgUrl = 'http://localhost:8000/topology.svg';
+
   /// トポロジJSONを取得。
-  static Future<Map<String, dynamic>> fetchTopologyJson() async {
+  static Future<Map<String, dynamic>> fetchTopologyJson({
+    http.Client? client,
+  }) async {
+    final http.Client c = client ?? http.Client();
+    try {
+      final res = await c
+          .get(Uri.parse(_jsonUrl))
+          .timeout(const Duration(milliseconds: 200));
+      if (res.statusCode == 200) {
+        return json.decode(res.body) as Map<String, dynamic>;
+      }
+    } catch (_) {
+      // ネットワーク取得失敗時はアセットを利用
+    } finally {
+      if (client == null) {
+        c.close();
+      }
+    }
     final jsonStr = await rootBundle.loadString('assets/topology.json');
     return json.decode(jsonStr) as Map<String, dynamic>;
   }
 
   /// トポロジSVGを取得。
-  static Future<String> fetchTopologySvg() {
+  static Future<String> fetchTopologySvg({http.Client? client}) async {
+    final http.Client c = client ?? http.Client();
+    try {
+      final res = await c
+          .get(Uri.parse(_svgUrl))
+          .timeout(const Duration(milliseconds: 200));
+      if (res.statusCode == 200) {
+        return res.body;
+      }
+    } catch (_) {
+      // ネットワーク取得失敗時はアセットを利用
+    } finally {
+      if (client == null) {
+        c.close();
+      }
+    }
     return rootBundle.loadString('assets/topology.svg');
   }
 }

--- a/nw_checker/test/network_diagram_page_test.dart
+++ b/nw_checker/test/network_diagram_page_test.dart
@@ -20,6 +20,14 @@ void main() {
     await tester.tap(find.byKey(const Key('node-router')));
     await tester.pumpAndSettle();
     expect(find.text('Router'), findsOneWidget);
+    final container = tester.widget<Container>(
+      find.descendant(
+        of: find.byKey(const Key('node-router')),
+        matching: find.byType(Container),
+      ),
+    );
+    final BoxDecoration? deco = container.decoration as BoxDecoration?;
+    expect(deco?.border, isNotNull);
 
     final viewerFinder = find.byKey(const Key('diagramViewer'));
     final controller = tester

--- a/nw_checker/test/network_scan_test.dart
+++ b/nw_checker/test/network_scan_test.dart
@@ -1,0 +1,38 @@
+import 'dart:convert';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:nw_checker/network_scan.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('fetches topology data from network when available', () async {
+    final client = MockClient((request) async {
+      if (request.url.path.endsWith('topology.json')) {
+        return http.Response('{"remote": true}', 200);
+      }
+      if (request.url.path.endsWith('topology.svg')) {
+        return http.Response('<svg><remote/></svg>', 200);
+      }
+      return http.Response('', 404);
+    });
+    final json = await NetworkScan.fetchTopologyJson(client: client);
+    final svg = await NetworkScan.fetchTopologySvg(client: client);
+    expect(json['remote'], isTrue);
+    expect(svg, contains('<remote/>'));
+  });
+
+  test('falls back to bundled assets on network failure', () async {
+    final assetJsonStr = await rootBundle.loadString('assets/topology.json');
+    final assetJson = json.decode(assetJsonStr) as Map<String, dynamic>;
+    final failClient = MockClient((request) async => http.Response('err', 500));
+    final jsonRes = await NetworkScan.fetchTopologyJson(client: failClient);
+    expect(jsonRes, assetJson);
+
+    final assetSvg = await rootBundle.loadString('assets/topology.svg');
+    final svgRes = await NetworkScan.fetchTopologySvg(client: failClient);
+    expect(svgRes, assetSvg);
+  });
+}


### PR DESCRIPTION
## Summary
- allow `NetworkScan` to inject an `http.Client` for testable remote fetch with asset fallback
- add unit tests covering network and fallback paths

## Testing
- `PYTHONPATH=. pytest`
- `cd nw_checker && flutter test`


------
https://chatgpt.com/codex/tasks/task_e_68a0a324aad48323b5f79554657142f8