### PR TITLE
Add basic Flutter widget tests

### DIFF
--- a/nw_checker/test/app_smoke_test.dart
+++ b/nw_checker/test/app_smoke_test.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nw_checker/main.dart';
+
+void main() {
+  testWidgets('MyApp builds MaterialApp', (WidgetTester tester) async {
+    await tester.pumpWidget(const MyApp());
+    expect(find.byType(MaterialApp), findsOneWidget);
+  });
+}

--- a/nw_checker/test/static_scan_tab_test.dart
+++ b/nw_checker/test/static_scan_tab_test.dart
@@ -3,6 +3,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:nw_checker/static_scan_tab.dart';
 
 void main() {
+  testWidgets('StaticScanTab shows Scan title', (WidgetTester tester) async {
+    await tester.pumpWidget(const MaterialApp(home: StaticScanTab()));
+    expect(find.textContaining('Scan'), findsOneWidget);
+  });
+
   test('performStaticScan returns summary and findings', () async {
     final result = await performStaticScan();
     expect(result.containsKey('summary'), isTrue);


### PR DESCRIPTION
## Summary
- move Flutter widget tests into app's test directory
- add smoke test for MyApp and title check for StaticScanTab

## Testing
- `flutter test test/app_smoke_test.dart test/static_scan_tab_test.dart`
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68a096af710083238c3b8882931183ac