### PR TITLE
Use real CLI calls and handle JsonFetchTab errors

### DIFF
--- a/nw_checker/lib/json_fetch_tab.dart
+++ b/nw_checker/lib/json_fetch_tab.dart
@@ -1,6 +1,8 @@
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
 
 /// Reusable tab widget that executes an async callback and displays JSON.
 class JsonFetchTab extends StatefulWidget {
@@ -30,12 +32,20 @@ class _JsonFetchTabState extends State<JsonFetchTab> {
     });
 
     await Future<void>.delayed(Duration.zero);
-    final result = await widget.fetcher();
-    if (!mounted) return;
-    setState(() {
-      _isLoading = false;
-      _data = result;
-    });
+    try {
+      final result = await widget.fetcher();
+      if (!mounted) return;
+      setState(() {
+        _isLoading = false;
+        _data = result;
+      });
+    } catch (_) {
+      if (!mounted) return;
+      setState(() {
+        _isLoading = false;
+        _data = {'message': '結果がありません'};
+      });
+    }
   }
 
   @override
@@ -44,8 +54,12 @@ class _JsonFetchTabState extends State<JsonFetchTab> {
     if (_isLoading) {
       child = const Center(child: CircularProgressIndicator());
     } else if (_data != null) {
-      final text = const JsonEncoder.withIndent('  ').convert(_data);
-      child = SingleChildScrollView(child: SelectableText(text));
+      if (_data!.length == 1 && _data!.containsKey('message')) {
+        child = Text(_data!['message'].toString());
+      } else {
+        final text = const JsonEncoder.withIndent('  ').convert(_data);
+        child = SingleChildScrollView(child: SelectableText(text));
+      }
     } else {
       child = ElevatedButton(
         key: widget.buttonKey,
@@ -59,13 +73,33 @@ class _JsonFetchTabState extends State<JsonFetchTab> {
 
 /// Default CLI-backed implementations for dynamic scan and network map.
 Future<Map<String, dynamic>> runDynamicCli() async {
-  // In production this would call a real CLI or backend service.
-  await Future.delayed(const Duration(seconds: 1));
-  return {'status': 'dynamic'};
+  try {
+    final resp = await http.get(
+      Uri.parse('http://localhost:8000/scan/dynamic/results'),
+    );
+    if (resp.statusCode == 200) {
+      return json.decode(resp.body) as Map<String, dynamic>;
+    }
+    return {'message': '結果がありません'};
+  } catch (_) {
+    return {'message': '結果がありません'};
+  }
 }
 
 Future<Map<String, dynamic>> runNetworkCli() async {
-  // In production this would call a real CLI or backend service.
-  await Future.delayed(const Duration(seconds: 1));
-  return {'status': 'network'};
+  try {
+    final result = await Process.run('python', [
+      '-m',
+      'src.network_map',
+      '192.168.0.0/24',
+    ]);
+    if (result.exitCode != 0) {
+      return {'message': '結果がありません'};
+    }
+    final lines = (result.stdout as String).trim().split('\n');
+    final hosts = json.decode(lines.first);
+    return {'hosts': hosts};
+  } catch (_) {
+    return {'message': '結果がありません'};
+  }
 }

--- a/nw_checker/test/json_fetch_functions_test.dart
+++ b/nw_checker/test/json_fetch_functions_test.dart
@@ -1,0 +1,39 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nw_checker/json_fetch_tab.dart';
+
+void main() {
+  group('runDynamicCli', () {
+    test('returns JSON on success', () async {
+      final server = await HttpServer.bind('localhost', 8000);
+      addTearDown(() => server.close(force: true));
+      server.listen((request) {
+        request.response
+          ..statusCode = 200
+          ..headers.contentType = ContentType.json
+          ..write('{"ok": true}')
+          ..close();
+      });
+      final result = await runDynamicCli();
+      expect(result, {'ok': true});
+    });
+
+    test('returns message when backend fails', () async {
+      final server = await HttpServer.bind('localhost', 8000);
+      addTearDown(() => server.close(force: true));
+      server.listen((request) {
+        request.response
+          ..statusCode = 500
+          ..close();
+      });
+      final result = await runDynamicCli();
+      expect(result, {'message': '結果がありません'});
+    });
+  });
+
+  test('runNetworkCli returns message on failure', () async {
+    final result = await runNetworkCli();
+    expect(result, {'message': '結果がありません'});
+  });
+}

--- a/nw_checker/test/json_fetch_tab_test.dart
+++ b/nw_checker/test/json_fetch_tab_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nw_checker/json_fetch_tab.dart';
+
+void main() {
+  testWidgets('shows message when fetcher fails', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: JsonFetchTab(
+          buttonText: 'run',
+          fetcher: _failingFetcher,
+          buttonKey: Key('runButton'),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('runButton')));
+    await tester.pump();
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    expect(find.text('結果がありません'), findsOneWidget);
+  });
+}
+
+Future<Map<String, dynamic>> _failingFetcher() async {
+  throw Exception('fail');
+}

--- a/nw_checker/test/widget_test.dart
+++ b/nw_checker/test/widget_test.dart
@@ -87,7 +87,7 @@ void main() {
     expect(find.byType(CircularProgressIndicator), findsOneWidget);
     await tester.pump(const Duration(seconds: 2));
     await tester.pump();
-    expect(find.textContaining('dynamic'), findsOneWidget);
+    expect(find.text('結果がありません'), findsOneWidget);
   });
 
   testWidgets('Test tab shows monospaced diagnostic text', (


### PR DESCRIPTION
## Summary
- Invoke backend API for dynamic scan and Python CLI for network map in `runDynamicCli` and `runNetworkCli`
- Catch fetch errors and surface '結果がありません' messages in `JsonFetchTab`
- Add regression tests for `JsonFetchTab` and update existing widget test
- Add unit tests for CLI helpers covering success and failure cases

## Testing
- `PYTHONPATH=. pytest`
- `cd nw_checker && flutter test`


------
https://chatgpt.com/codex/tasks/task_e_68a0ab6773b88323a66dd8200f88b292