### PR TITLE
feat: show remaining time in test tab

### DIFF
--- a/nw_checker/test/test_tab_loading_indicator_test.dart
+++ b/nw_checker/test/test_tab_loading_indicator_test.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:nw_checker/main.dart';
+
+void main() {
+  testWidgets('Test tab displays countdown and progress', (tester) async {
+    await tester.pumpWidget(const MyApp());
+
+    await tester.tap(find.byKey(const Key('testTab')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('テストを実行'));
+    await tester.pump();
+
+    expect(find.byKey(const Key('remainingText')), findsOneWidget);
+    expect(find.text('残り時間: 30 秒'), findsOneWidget);
+
+    await tester.pump(const Duration(seconds: 5));
+    expect(find.text('残り時間: 25 秒'), findsOneWidget);
+    final progress = tester
+        .widget<LinearProgressIndicator>(find.byType(LinearProgressIndicator))
+        .value;
+    expect(progress, closeTo(5 / 30, 0.01));
+
+    await tester.pump(const Duration(seconds: 25));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const ValueKey('report')), findsOneWidget);
+  });
+
+  testWidgets('Restarting test resets timer and progress', (tester) async {
+    await tester.pumpWidget(const MyApp());
+
+    await tester.tap(find.byKey(const Key('testTab')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('テストを実行'));
+    await tester.pump();
+
+    await tester.pump(const Duration(seconds: 10));
+    expect(find.text('残り時間: 20 秒'), findsOneWidget);
+    var progress = tester
+        .widget<LinearProgressIndicator>(find.byType(LinearProgressIndicator))
+        .value;
+    expect(progress, closeTo(10 / 30, 0.01));
+
+    await tester.tap(find.text('テストを実行'));
+    await tester.pump();
+
+    expect(find.text('残り時間: 30 秒'), findsOneWidget);
+    progress = tester
+        .widget<LinearProgressIndicator>(find.byType(LinearProgressIndicator))
+        .value;
+    expect(progress, closeTo(0, 0.01));
+
+    await tester.pump(const Duration(seconds: 5));
+    expect(find.text('残り時間: 25 秒'), findsOneWidget);
+
+    await tester.pump(const Duration(seconds: 30));
+    await tester.pumpAndSettle();
+  });
+}

--- a/nw_checker/test/widget_test.dart
+++ b/nw_checker/test/widget_test.dart
@@ -49,7 +49,7 @@ void main() {
     expect(find.byType(SelectableText), findsNothing);
     await tester.tap(find.text('テストを実行'));
     await tester.pump();
-    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    expect(find.byType(LinearProgressIndicator), findsOneWidget);
     expect(find.byType(SelectableText), findsNothing);
     await tester.pump(const Duration(seconds: 30));
     await tester.pumpAndSettle();
@@ -103,7 +103,7 @@ void main() {
 
     await tester.tap(find.text('テストを実行'));
     await tester.pump();
-    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    expect(find.byType(LinearProgressIndicator), findsOneWidget);
     await tester.pump(const Duration(seconds: 30));
     await tester.pumpAndSettle();
 


### PR DESCRIPTION
## Summary
- display countdown timer and progress bar during test tab run
- clarify loading state with message updates
- cover new behavior with widget tests
- add regression test ensuring restart resets countdown and progress

## Testing
- `PYTHONPATH=. pytest`
- `cd nw_checker && flutter test`


------
https://chatgpt.com/codex/tasks/task_e_68a0ab3896ac83238babaaf26b72cdbd