### PR TITLE
feat: improve static scan error visibility

### DIFF
--- a/nw_checker/lib/static_scan_tab.dart
+++ b/nw_checker/lib/static_scan_tab.dart
@@ -23,7 +23,7 @@ Future<Map<String, dynamic>> performStaticScan({http.Client? client}) async {
       try {
         final err = jsonDecode(resp.body);
         if (err is Map && err['detail'] != null) {
-          message = err['detail'].toString();
+          message = 'HTTP ${resp.statusCode}: ${err['detail']}';
         } else {
           message = 'HTTP ${resp.statusCode}';
         }
@@ -37,8 +37,9 @@ Future<Map<String, dynamic>> performStaticScan({http.Client? client}) async {
     }
   } catch (e) {
     // 例外発生時は例外メッセージを返す
+    final msg = e.toString();
     return {
-      'summary': ['スキャン失敗: $e'],
+      'summary': ['スキャン失敗: $msg'],
       'findings': [],
     };
   } finally {

--- a/nw_checker/test/static_scan_tab_test.dart
+++ b/nw_checker/test/static_scan_tab_test.dart
@@ -37,6 +37,25 @@ void main() {
     expect(result['findings'], isEmpty);
   });
 
+  testWidgets('HTTP error from performStaticScan is shown in UI',
+      (tester) async {
+    final client = MockClient((request) async {
+      return http.Response('{"detail": "server down"}', 503);
+    });
+
+    Future<Map<String, dynamic>> scanner() => performStaticScan(client: client);
+
+    await tester.pumpWidget(
+      MaterialApp(home: StaticScanTab(scanner: scanner)),
+    );
+
+    await tester.tap(find.byKey(const Key('staticButton')));
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    expect(find.text('スキャン失敗: HTTP 503: server down'), findsOneWidget);
+  });
+
   testWidgets('error summary is displayed to user', (tester) async {
     Future<Map<String, dynamic>> mockScan() async {
       return {

--- a/nw_checker/test/static_scan_tab_test.dart
+++ b/nw_checker/test/static_scan_tab_test.dart
@@ -24,7 +24,7 @@ void main() {
       return http.Response('{"detail": "fail"}', 500);
     });
     final result = await performStaticScan(client: client);
-    expect(result['summary'], ['スキャン失敗: fail']);
+    expect(result['summary'], ['スキャン失敗: HTTP 500: fail']);
     expect(result['findings'], isEmpty);
   });
 


### PR DESCRIPTION
## Summary
- include HTTP status code in static scan error messages
- adjust tests for updated error formatting

## Testing
- `pytest` *(fails: fastapi が無いので Codex/Windows では pytest 全体を skip)*
- `flutter test test/static_scan_tab_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_68a16388d6748323928577730d9775c8