### PR TITLE
Implement concurrent static scan runner

### DIFF
--- a/tests/test_static_scan_discovery.py
+++ b/tests/test_static_scan_discovery.py
@@ -1,0 +1,33 @@
+import time
+from src import static_scan
+
+def test_load_scanners_discovers_modules():
+    scanners = static_scan._load_scanners()
+    names = {name for name, _ in scanners}
+    # Ensure common scan modules are discovered
+    assert {'ports', 'os_banner'}.issubset(names)
+
+def test_run_all_executes_scanners_concurrently(monkeypatch):
+    """Scans should run in parallel to reduce total execution time."""
+
+    def make_slow(name):
+        def slow_scan():
+            time.sleep(1)
+            return {"category": name, "score": 1, "details": {}}
+        return slow_scan
+
+    monkeypatch.setattr(
+        static_scan,
+        "_load_scanners",
+        lambda: [("slow1", make_slow("slow1")), ("slow2", make_slow("slow2"))],
+    )
+
+    start = time.perf_counter()
+    result = static_scan.run_all()
+    elapsed = time.perf_counter() - start
+
+    # Would take ~2s sequentially; concurrent run should be significantly faster
+    assert elapsed < 1.8
+    assert result["risk_score"] == 2
+    categories = [item["category"] for item in result["findings"]]
+    assert {"slow1", "slow2"} == set(categories)


### PR DESCRIPTION
## Summary
- dynamically load scan modules and execute them concurrently
- aggregate per-scan results and compute overall risk score
- add tests verifying module discovery and parallel execution

## Testing
- `pytest tests/test_static_scan.py tests/test_static_scan_discovery.py`

------
https://chatgpt.com/codex/tasks/task_e_68a2e698d9908323a9b3620236974a9c