### PR TITLE
feat: centralize API base URL configuration

### DIFF
--- a/nw_checker/lib/api_config.dart
+++ b/nw_checker/lib/api_config.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'dart:io' show Platform;
+import 'package:meta/meta.dart';
+
+/// Returns the base URL for API calls.
+///
+/// [--dart-define=API_BASE_URL] can override the value.
+String baseUrl() {
+  final override = _envApiBaseUrl();
+  if (override.isNotEmpty) {
+    return override;
+  }
+  if (_isWeb()) {
+    return 'http://localhost:8000';
+  }
+  if (_platformIsAndroid()) {
+    // Android エミュレータからホストのlocalhostにアクセスする場合
+    return 'http://10.0.2.2:8000';
+  }
+  return 'http://localhost:8000';
+}
+
+String Function() _envApiBaseUrl = () =>
+    const String.fromEnvironment('API_BASE_URL', defaultValue: '');
+
+bool Function() _isWeb = () => kIsWeb;
+
+bool Function() _platformIsAndroid = () => Platform.isAndroid;
+
+/// 以下はテスト用ヘルパー。
+@visibleForTesting
+void setEnvApiBaseUrlForTest(String Function() fn) {
+  _envApiBaseUrl = fn;
+}
+
+@visibleForTesting
+void resetEnvApiBaseUrlForTest() {
+  _envApiBaseUrl = () =>
+      const String.fromEnvironment('API_BASE_URL', defaultValue: '');
+}
+
+@visibleForTesting
+void setIsWebForTest(bool Function() fn) {
+  _isWeb = fn;
+}
+
+@visibleForTesting
+void resetIsWebForTest() {
+  _isWeb = () => kIsWeb;
+}
+
+@visibleForTesting
+void setPlatformIsAndroidForTest(bool Function() fn) {
+  _platformIsAndroid = fn;
+}
+
+@visibleForTesting
+void resetPlatformIsAndroidForTest() {
+  _platformIsAndroid = () => Platform.isAndroid;
+}

--- a/nw_checker/lib/services/dynamic_scan_api.dart
+++ b/nw_checker/lib/services/dynamic_scan_api.dart
@@ -1,12 +1,13 @@
 import 'dart:async';
 import 'dart:convert';
+import '../api_config.dart';
 import '../models/scan_report.dart';
 import 'package:http/http.dart' as http;
 
 /// ダミーの動的スキャンAPI。
 /// 実際のバックエンドとの通信は今後実装予定。
 class DynamicScanApi {
-  static const _baseUrl = 'http://localhost:8000';
+  static String get _baseUrl => baseUrl();
   static const String _token = String.fromEnvironment(
     'API_TOKEN',
     defaultValue: '',

--- a/nw_checker/lib/static_scan_tab.dart
+++ b/nw_checker/lib/static_scan_tab.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
+import 'api_config.dart';
 
 /// 静的スキャンAPIを呼び出し結果を返す
 Future<Map<String, dynamic>> performStaticScan({http.Client? client}) async {
@@ -9,7 +10,7 @@ Future<Map<String, dynamic>> performStaticScan({http.Client? client}) async {
   final c = client ?? http.Client();
   try {
     final resp = await c
-        .get(Uri.parse('http://localhost:8000/static_scan'))
+        .get(Uri.parse('${baseUrl()}/static_scan'))
         .timeout(const Duration(seconds: 5));
     if (resp.statusCode == 200) {
       final decoded = jsonDecode(resp.body) as Map<String, dynamic>;

--- a/nw_checker/test/api_config_test.dart
+++ b/nw_checker/test/api_config_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nw_checker/api_config.dart';
+
+void main() {
+  setUp(() {
+    resetEnvApiBaseUrlForTest();
+    resetIsWebForTest();
+    resetPlatformIsAndroidForTest();
+  });
+
+  group('baseUrl', () {
+    test('returns Android emulator host on Android', () {
+      setPlatformIsAndroidForTest(() => true);
+      expect(baseUrl(), 'http://10.0.2.2:8000');
+    });
+
+    test('returns localhost on non-Android', () {
+      setPlatformIsAndroidForTest(() => false);
+      expect(baseUrl(), 'http://localhost:8000');
+    });
+
+    test('returns override when API_BASE_URL is defined', () {
+      setEnvApiBaseUrlForTest(() => 'https://example.com');
+      setPlatformIsAndroidForTest(() => true);
+      expect(baseUrl(), 'https://example.com');
+    });
+
+    test('returns localhost for web even on Android', () {
+      setIsWebForTest(() => true);
+      setPlatformIsAndroidForTest(() => true);
+      expect(baseUrl(), 'http://localhost:8000');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add `baseUrl()` helper using kIsWeb and Platform checks with `--dart-define=API_BASE_URL` override
- use `baseUrl()` in static scan and dynamic scan API
- test base URL selection across platforms

## Testing
- `cd nw_checker && flutter test`


------
https://chatgpt.com/codex/tasks/task_e_68a2f0dd3238832399197a1084cadc20