### PR TITLE
feat: add underscore aliases for dynamic scan

### DIFF
--- a/docs/dynamic_scan_api.md
+++ b/docs/dynamic_scan_api.md
@@ -1,0 +1,48 @@
+# Dynamic Scan API
+
+Endpoints to control and retrieve results from the dynamic scan scheduler.
+Both kebab-case (`/dynamic-scan/*`) and underscore (`/dynamic_scan/*`) paths
+are supported for backward compatibility.
+
+## Start Scan
+
+- **Method**: `POST`
+- **Paths**: `/dynamic-scan/start`, `/dynamic_scan/start`
+- **Body** (`StartParams`):
+  - `interface` *(optional, string)*: network interface to capture packets from
+  - `duration` *(optional, int)*: capture duration in seconds
+  - `approved_macs` *(optional, list[str])*: allowed MAC addresses
+  - `interval` *(optional, int)*: rescan interval in seconds (default 3600)
+
+### Successful Response
+
+```json
+{"status": "scheduled"}
+```
+
+## Stop Scan
+
+- **Method**: `POST`
+- **Paths**: `/dynamic-scan/stop`, `/dynamic_scan/stop`
+
+### Successful Response
+
+```json
+{"status": "stopped"}
+```
+
+## Get Results
+
+- **Method**: `GET`
+- **Paths**: `/dynamic-scan/results`, `/dynamic_scan/results`
+
+### Successful Response
+
+```json
+{
+  "risk_score": 1,
+  "categories": [
+    {"name": "protocols", "severity": "high", "issues": ["ftp"]}
+  ]
+}
+```

--- a/src/api.py
+++ b/src/api.py
@@ -123,6 +123,24 @@ async def get_results_v2():
     """
     return await get_results()
 
+# アンダースコア形式のエンドポイント (/dynamic_scan/*) へのエイリアス
+@app.post("/dynamic_scan/start")
+async def start_scan_v3(params: StartParams):
+    """動的スキャン開始エイリアス（アンダースコア形式）"""
+    return await start_scan_v2(params)
+
+
+@app.post("/dynamic_scan/stop")
+async def stop_scan_v3():
+    """動的スキャン停止エイリアス（アンダースコア形式）"""
+    return await stop_scan_v2()
+
+
+@app.get("/dynamic_scan/results")
+async def get_results_v3():
+    """動的スキャン結果取得エイリアス（アンダースコア形式）"""
+    return await get_results_v2()
+
 
 @app.get("/scan/dynamic/history")
 async def get_history(

--- a/tests/test_api_dynamic_scan_underscore_alias.py
+++ b/tests/test_api_dynamic_scan_underscore_alias.py
@@ -1,0 +1,58 @@
+import asyncio
+from fastapi.testclient import TestClient
+
+from src import api
+from src.dynamic_scan import scheduler, storage, capture, analyze
+
+
+def test_dynamic_scan_start_stop_underscore_alias(monkeypatch, tmp_path):
+    client = TestClient(api.app)
+    store = storage.Storage(tmp_path / "res.db")
+    monkeypatch.setattr(storage, "Storage", lambda *args, **kwargs: store)
+
+    async def dummy_capture(queue, interface=None, duration=None):
+        return
+
+    async def dummy_analyse(queue, storage_obj, approved_macs=None):
+        return
+
+    monkeypatch.setattr(capture, "capture_packets", dummy_capture)
+    monkeypatch.setattr(analyze, "analyse_packets", dummy_analyse)
+
+    # start aliases behave identically
+    api.scan_scheduler = scheduler.DynamicScanScheduler()
+    resp_hyphen = client.post("/dynamic-scan/start", json={"duration": 0})
+    asyncio.run(api.scan_scheduler.stop())
+
+    api.scan_scheduler = scheduler.DynamicScanScheduler()
+    resp_underscore = client.post("/dynamic_scan/start", json={"duration": 0})
+    assert resp_hyphen.status_code == resp_underscore.status_code == 200
+    assert resp_hyphen.json() == resp_underscore.json() == {"status": "scheduled"}
+    asyncio.run(api.scan_scheduler.stop())
+
+    # stop aliases behave identically
+    api.scan_scheduler = scheduler.DynamicScanScheduler()
+    client.post("/dynamic-scan/start", json={"duration": 0})
+    resp_hyphen_stop = client.post("/dynamic-scan/stop")
+
+    api.scan_scheduler = scheduler.DynamicScanScheduler()
+    client.post("/dynamic_scan/start", json={"duration": 0})
+    resp_underscore_stop = client.post("/dynamic_scan/stop")
+    assert resp_hyphen_stop.status_code == resp_underscore_stop.status_code == 200
+    assert resp_hyphen_stop.json() == resp_underscore_stop.json() == {"status": "stopped"}
+
+
+def test_dynamic_scan_results_underscore_alias(monkeypatch, tmp_path):
+    client = TestClient(api.app)
+    store = storage.Storage(tmp_path / "res.db")
+    api.scan_scheduler = scheduler.DynamicScanScheduler()
+    monkeypatch.setattr(storage, "Storage", lambda *args, **kwargs: store)
+
+    asyncio.run(api.scan_scheduler.storage.save_result({"protocol": "ftp"}))
+
+    resp_hyphen = client.get("/dynamic-scan/results")
+    resp_underscore = client.get("/dynamic_scan/results")
+
+    assert resp_hyphen.status_code == 200
+    assert resp_underscore.status_code == 200
+    assert resp_hyphen.json() == resp_underscore.json()


### PR DESCRIPTION
## Summary
- add `/dynamic_scan/*` routes mapping to existing `/dynamic-scan/*` handlers
- document dynamic scan API supporting kebab-case and underscore paths
- test underscore aliases for start, stop and results

## Testing
- `pytest tests/test_api_dynamic_scan_underscore_alias.py tests/test_api_dynamic_scan_alias.py`


------
https://chatgpt.com/codex/tasks/task_e_68a2f0e2314c8323b98b148120cbc843