### PR TITLE
feat: add concurrent static scan runner

### DIFF
--- a/tests/test_static_scan_discovery.py
+++ b/tests/test_static_scan_discovery.py
@@ -31,3 +31,11 @@ def test_run_all_executes_scanners_concurrently(monkeypatch):
     assert result["risk_score"] == 2
     categories = [item["category"] for item in result["findings"]]
     assert {"slow1", "slow2"} == set(categories)
+
+
+def test_run_all_handles_no_scanners(monkeypatch):
+    """When no scanners are discovered, run_all should return empty results."""
+    monkeypatch.setattr(static_scan, "_load_scanners", lambda: [])
+    result = static_scan.run_all()
+    assert result["findings"] == []
+    assert result["risk_score"] == 0


### PR DESCRIPTION
## Summary
- implement helper to dynamically load scan modules
- run scan modules concurrently and aggregate results with risk score
- add test ensuring run_all handles empty scanner sets

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_68a32d64e39083238d7e347ccb21b4f4