### PR TITLE
feat: run all static scans concurrently

### DIFF
--- a/src/static_scan.py
+++ b/src/static_scan.py
@@ -40,32 +40,47 @@ def run_all(timeout: float = 5.0) -> Dict[str, List[Dict]]:
         the aggregated ``risk_score``.
     """
 
-    # Discover available scanners then prioritise important ones.
+    # Discover available scanners then prioritise important ones.  The first
+    # two results should always be ``ports`` followed by ``os_banner`` so the
+    # API responses remain consistent.
     scanners = _load_scanners()
     priority = ["ports", "os_banner"]
-    scanners.sort(key=lambda x: priority.index(x[0]) if x[0] in priority else len(priority))
+    scanners.sort(
+        key=lambda x: priority.index(x[0]) if x[0] in priority else len(priority)
+    )
 
     findings: List[Dict] = []
-    risk_score = 0
 
-    # Run all scanners concurrently while keeping the execution order defined
-    # above so that tests can rely on deterministic output positions.
+    # Run all scanners concurrently while preserving the deterministic order
+    # established above.  Each scanner is allowed ``timeout`` seconds to
+    # complete; on timeout or failure we record an error entry with score 0.
     with ThreadPoolExecutor() as pool:
         futures = [(name, pool.submit(scan)) for name, scan in scanners]
         for name, future in futures:
             try:
                 result = future.result(timeout=timeout)
             except TimeoutError:
-                result = {"category": name, "score": 0, "details": {"error": "timeout"}}
+                result = {
+                    "category": name,
+                    "score": 0,
+                    "details": {"error": "timeout"},
+                }
             except Exception as exc:  # noqa: BLE001 - surface scan errors
-                result = {"category": name, "score": 0, "details": {"error": str(exc)}}
+                result = {
+                    "category": name,
+                    "score": 0,
+                    "details": {"error": str(exc)},
+                }
             else:
-                # Ensure mandatory fields exist even if the scanner omitted them.
+                # Ensure mandatory fields exist even if the scanner omitted
+                # them.
                 result.setdefault("category", name)
                 result.setdefault("score", 0)
                 result.setdefault("details", {})
 
             findings.append(result)
-            risk_score += result.get("score", 0)
+
+    # ``risk_score`` は各スキャンの ``score`` の合計値
+    risk_score = sum(item.get("score", 0) for item in findings)
 
     return {"findings": findings, "risk_score": risk_score}


### PR DESCRIPTION
## Summary
- run each static scanner concurrently with fault-tolerant aggregation
- add regression test ensuring default scanners are prioritised in results

## Testing
- `pytest tests/test_static_scan.py tests/test_static_scan_discovery.py -q` *(fails: Skipped: fastapi が無いので Codex/Windows では pytest 全体を skip)*

------
https://chatgpt.com/codex/tasks/task_e_68a718a06b508323b2b4d7936a329750