### PR TITLE
Add timeout test for StaticScanApi.fetchScan

### DIFF
--- a/nw_checker/test/static_scan_api_test.dart
+++ b/nw_checker/test/static_scan_api_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
@@ -21,5 +23,23 @@ void main() {
       return http.Response('{"detail": "fail"}', 500);
     });
     expect(StaticScanApi.fetchScan(client: client), throwsA(isA<Exception>()));
+  });
+
+  test('fetchScan throws on timeout', () async {
+    final client = MockClient((request) async {
+      return Future.delayed(
+        const Duration(seconds: 6),
+        () => http.Response('{}', 200),
+      );
+    });
+
+    expect(() async {
+      try {
+        await StaticScanApi.fetchScan(client: client);
+      } finally {
+        // Ensure client can still be closed gracefully after a timeout.
+        client.close();
+      }
+    }, throwsA(isA<TimeoutException>()));
   });
 }


### PR DESCRIPTION
## Summary
- add unit test verifying StaticScanApi.fetchScan throws TimeoutException when request exceeds 5s
- ensure client can be closed gracefully after timeout

## Testing
- `flutter test test/static_scan_api_test.dart`
- `pytest` *(fails: Skipped: fastapi が無いので Codex/Windows では pytest 全体を skip)*

------
https://chatgpt.com/codex/tasks/task_e_68a88a85e37c8323a74624b853493063