### PR TITLE
test: add placeholder check for empty static scan results

### DIFF
--- a/nw_checker/test/static_scan_tab_test.dart
+++ b/nw_checker/test/static_scan_tab_test.dart
@@ -65,4 +65,25 @@ void main() {
 
     expect(find.text('ok'), findsOneWidget);
   });
+
+  testWidgets('shows placeholder when no findings', (tester) async {
+    Future<Map<String, dynamic>> mockFetch() async {
+      return {
+        'risk_score': 0,
+        'findings': [],
+      };
+    }
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(body: StaticScanTab(fetcher: mockFetch)),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('staticButton')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('結果なし'), findsOneWidget);
+    expect(find.textContaining('リスクスコア'), findsNothing);
+  });
 }


### PR DESCRIPTION
## Summary
- ensure StaticScanTab shows placeholder when no findings

## Testing
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_68a88a7b597083239dbd32632d948911