### PR TITLE
feat: enrich host discovery with vendor lookup

### DIFF
--- a/src/discover_hosts.py
+++ b/src/discover_hosts.py
@@ -1,8 +1,12 @@
 """LAN host discovery utilities."""
 
+import re
 import socket
 import subprocess
+from pathlib import Path
 from typing import Dict, List, Optional
+
+import requests
 
 
 def _verify_host(ip: str, port: int = 80, timeout: float = 0.1) -> bool:
@@ -23,12 +27,39 @@ def _verify_host(ip: str, port: int = 80, timeout: float = 0.1) -> bool:
         sock.close()
 
 
+def _lookup_vendor(mac: str) -> Optional[str]:
+    """Return vendor name for *mac* using ``oui.txt`` or external API."""
+    prefix = mac.upper().replace("-", "").replace(":", "")[:6]
+    oui_path = Path(__file__).resolve().parent.parent / "data" / "oui.txt"
+    if oui_path.exists():
+        try:
+            with oui_path.open() as f:
+                for line in f:
+                    line = line.strip()
+                    if not line or line.startswith("#"):
+                        continue
+                    parts = line.split(None, 1)
+                    key = parts[0].replace("-", "").replace(":", "").upper()
+                    if key == prefix:
+                        return parts[1].strip() if len(parts) > 1 else None
+        except OSError:
+            pass
+    try:  # Fallback to API lookup
+        resp = requests.get(f"https://api.macvendors.com/{mac}", timeout=5)
+        if resp.status_code == 200:
+            return resp.text.strip()
+    except Exception:
+        pass
+    return None
+
+
 def _run_nmap_scan(subnet: str) -> List[Dict[str, Optional[str]]]:
     """Run an nmap scan and return discovered hosts.
 
-    Each host is represented as a dict with ``ip`` and optional ``hostname``
-    fields.  The ``-R`` option forces reverse DNS resolution so that nmap tries
-    to determine hostnames for all targets.
+    Each host is represented as a dict with ``ip`` and optional ``hostname`` and
+    ``vendor`` fields.  The ``-R`` option forces reverse DNS resolution so that
+    nmap tries to determine hostnames for all targets.  ``nbtscan`` and
+    ``avahi-resolve`` are consulted when nmap does not provide a hostname.
     """
     try:
         output = subprocess.check_output(
@@ -37,19 +68,47 @@ def _run_nmap_scan(subnet: str) -> List[Dict[str, Optional[str]]]:
     except (OSError, subprocess.CalledProcessError):
         return []
 
-    hosts: List[Dict[str, Optional[str]]] = []
+    host_map: Dict[str, Dict[str, Optional[str]]] = {}
+    host_re = re.compile(r"^Host:\s+(\S+)\s+\(([^)]*)\)")
+    mac_re = re.compile(r"MAC Address:\s+([0-9A-Fa-f:]{17})(?:\s+\(([^)]+)\))?")
+
     for line in output.splitlines():
         line = line.strip()
         if not line.startswith("Host:"):
             continue
-        # Example line: "Host: 192.168.0.1 (router)\tStatus: Up"
-        parts = line.split()
-        ip = parts[1]
-        hostname: Optional[str] = None
-        if len(parts) > 2 and parts[2].startswith("("):
-            hostname = parts[2].strip("()")
-        hosts.append({"ip": ip, "hostname": hostname})
-    return hosts
+        m_host = host_re.search(line)
+        if not m_host:
+            continue
+        ip = m_host.group(1)
+        hostname = m_host.group(2) or None
+        entry = host_map.setdefault(
+            ip, {"ip": ip, "hostname": hostname, "mac": None, "vendor": None}
+        )
+        if hostname and not entry.get("hostname"):
+            entry["hostname"] = hostname
+        m_mac = mac_re.search(line)
+        if m_mac:
+            entry["mac"] = m_mac.group(1)
+            if m_mac.group(2):
+                entry["vendor"] = m_mac.group(2)
+
+    for host in host_map.values():
+        if not host.get("hostname"):
+            hostname = _get_hostname_nbtscan(host["ip"])
+            if not hostname:
+                hostname = _get_hostname_avahi(host["ip"])
+            if hostname:
+                host["hostname"] = hostname
+        if host.get("mac") and not host.get("vendor"):
+            vendor = _lookup_vendor(host["mac"])
+            if vendor:
+                host["vendor"] = vendor
+
+    results: List[Dict[str, Optional[str]]] = []
+    for info in host_map.values():
+        entry = {"ip": info["ip"], "hostname": info.get("hostname"), "vendor": info.get("vendor")}
+        results.append(entry)
+    return results
 
 
 def _get_hostname_nbtscan(ip: str) -> Optional[str]:
@@ -85,18 +144,7 @@ def discover_hosts(subnet: str) -> List[Dict[str, str]]:
 
     The current implementation delegates the heavy lifting to ``nmap`` to obtain
     a list of candidate hosts.  Each candidate is probed via
-    :func:`_verify_host` to confirm reachability.  If ``nmap`` did not provide a
-    hostname, ``nbtscan`` or ``avahi-resolve`` is invoked to attempt name
-    resolution.
+    :func:`_verify_host` to confirm reachability.  Hostname resolution and
+    vendor lookup are handled within :func:`_run_nmap_scan`.
     """
-    hosts = [h for h in _run_nmap_scan(subnet) if _verify_host(h["ip"]) ]
-
-    for host in hosts:
-        if host.get("hostname"):
-            continue
-        hostname = _get_hostname_nbtscan(host["ip"])
-        if not hostname:
-            hostname = _get_hostname_avahi(host["ip"])
-        if hostname:
-            host["hostname"] = hostname
-    return hosts
+    return [h for h in _run_nmap_scan(subnet) if _verify_host(h["ip"])]

--- a/src/topology_builder.py
+++ b/src/topology_builder.py
@@ -117,5 +117,6 @@ def build_topology_for_subnet(subnet: str, use_snmp: bool = False, community: st
         JSON string containing a ``paths`` array, same as
         :func:`build_topology`.
     """
-    hosts = discover_hosts.discover_hosts(subnet)
+    discovered = discover_hosts.discover_hosts(subnet)
+    hosts = [h["ip"] if isinstance(h, dict) else h for h in discovered]
     return build_topology(hosts, use_snmp=use_snmp, community=community)

--- a/tests/test_discover_hosts.py
+++ b/tests/test_discover_hosts.py
@@ -3,25 +3,49 @@
 import socket
 import subprocess
 
+import requests
+from pathlib import Path
+
 from src.discover_hosts import discover_hosts
 
 
-def test_discover_hosts_resolves_hostname(monkeypatch):
-    """Ensure host discovery and hostname resolution work."""
+def test_discover_hosts_resolves_hostname_and_vendor(monkeypatch):
+    """Ensure host discovery returns hostnames and vendors."""
 
     def fake_check_output(cmd, text=True):
         if cmd[:2] == ["nmap", "-sn"]:
             assert cmd == ["nmap", "-sn", "-oG", "-", "-R", "192.168.0.0/24"]
             return (
                 "Host: 192.168.0.10 (printer) Status: Up\n"
+                "Host: 192.168.0.10 () MAC Address: 00:11:22:33:44:55\n"
                 "Host: 192.168.0.20 Status: Up\n"
+                "Host: 192.168.0.20 () MAC Address: 66:77:88:99:AA:BB\n"
             )
         if cmd[0] == "nbtscan":
             assert cmd == ["nbtscan", "-q", "192.168.0.20"]
             return "192.168.0.20 host20\n"
+        if cmd[0] == "avahi-resolve":
+            raise AssertionError("avahi-resolve should not be called when nbtscan succeeds")
         raise AssertionError(f"Unexpected command: {cmd}")
 
     monkeypatch.setattr(subprocess, "check_output", fake_check_output)
+
+    api_calls = []
+
+    def fake_get(url, timeout=5):
+        api_calls.append(url)
+        mac = url.rsplit("/", 1)[1]
+        mapping = {
+            "00:11:22:33:44:55": "VendorA",
+            "66:77:88:99:AA:BB": "VendorB",
+        }
+        class Resp:
+            status_code = 200
+            text = mapping[mac]
+
+        return Resp()
+
+    monkeypatch.setattr(requests, "get", fake_get)
 
     class DummySocket:
         def __init__(self, *args, **kwargs):
@@ -40,9 +64,13 @@ def test_discover_hosts_resolves_hostname(monkeypatch):
 
     result = discover_hosts("192.168.0.0/24")
     assert result == [
-        {"ip": "192.168.0.10", "hostname": "printer"},
-        {"ip": "192.168.0.20", "hostname": "host20"},
+        {"ip": "192.168.0.10", "hostname": "printer", "vendor": "VendorA"},
+        {"ip": "192.168.0.20", "hostname": "host20", "vendor": "VendorB"},
     ]
+    assert set(api_calls) == {
+        "https://api.macvendors.com/00:11:22:33:44:55",
+        "https://api.macvendors.com/66:77:88:99:AA:BB",
+    }
 
 
 def test_discover_hosts_avahi_fallback(monkeypatch):
@@ -54,7 +82,10 @@ def test_discover_hosts_avahi_fallback(monkeypatch):
         calls.append(cmd)
         if cmd[:2] == ["nmap", "-sn"]:
             assert cmd == ["nmap", "-sn", "-oG", "-", "-R", "192.168.0.0/24"]
-            return "Host: 192.168.0.30 Status: Up\n"
+            return (
+                "Host: 192.168.0.30 Status: Up\n"
+                "Host: 192.168.0.30 () MAC Address: AA:BB:CC:DD:EE:FF\n"
+            )
         if cmd[0] == "nbtscan":
             assert cmd == ["nbtscan", "-q", "192.168.0.30"]
             raise subprocess.CalledProcessError(1, cmd)
@@ -64,6 +95,16 @@ def test_discover_hosts_avahi_fallback(monkeypatch):
         raise AssertionError(f"Unexpected command: {cmd}")
 
     monkeypatch.setattr(subprocess, "check_output", fake_check_output)
+
+    def fake_get(url, timeout=5):
+        assert url == "https://api.macvendors.com/AA:BB:CC:DD:EE:FF"
+        class Resp:
+            status_code = 200
+            text = "VendorC"
+
+        return Resp()
+
+    monkeypatch.setattr(requests, "get", fake_get)
 
     class DummySocket:
         def __init__(self, *args, **kwargs):
@@ -81,7 +122,51 @@ def test_discover_hosts_avahi_fallback(monkeypatch):
     monkeypatch.setattr(socket, "socket", lambda *a, **kw: DummySocket())
 
     result = discover_hosts("192.168.0.0/24")
-    assert result == [{"ip": "192.168.0.30", "hostname": "host30"}]
+    assert result == [{"ip": "192.168.0.30", "hostname": "host30", "vendor": "VendorC"}]
     # ensure nbtscan was tried before avahi-resolve
     assert calls[1][0] == "nbtscan"
     assert calls[2][0] == "avahi-resolve"
+
+
+def test_discover_hosts_vendor_from_local_oui(monkeypatch):
+    """Use local ``oui.txt`` instead of API when available."""
+
+    data_dir = Path(__file__).resolve().parent.parent / "data"
+    data_dir.mkdir(exist_ok=True)
+    oui_path = data_dir / "oui.txt"
+    oui_path.write_text("00:11:22 VendorLocal\n")
+
+    def fake_check_output(cmd, text=True):
+        if cmd[:2] == ["nmap", "-sn"]:
+            assert cmd == ["nmap", "-sn", "-oG", "-", "-R", "192.168.0.0/24"]
+            return (
+                "Host: 192.168.0.40 (host40) Status: Up\n"
+                "Host: 192.168.0.40 () MAC Address: 00:11:22:AA:BB:CC\n"
+            )
+        raise AssertionError(f"Unexpected command: {cmd}")
+
+    monkeypatch.setattr(subprocess, "check_output", fake_check_output)
+
+    def fake_get(url, timeout=5):
+        raise AssertionError("API should not be called when oui.txt exists")
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    class DummySocket:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def settimeout(self, timeout):
+            pass
+
+        def connect(self, addr):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(socket, "socket", lambda *a, **kw: DummySocket())
+    monkeypatch.addfinalizer(lambda: oui_path.unlink())
+
+    result = discover_hosts("192.168.0.0/24")
+    assert result == [{"ip": "192.168.0.40", "hostname": "host40", "vendor": "VendorLocal"}]

--- a/tests/test_network_map.py
+++ b/tests/test_network_map.py
@@ -14,23 +14,23 @@ def test_network_map_delegates(monkeypatch):
 
     def fake_discover(subnet):
         calls["subnet"] = subnet
-        return ["10.0.0.1"]
+        return [{"ip": "10.0.0.1"}]
 
     monkeypatch.setattr(network_map, "discover_hosts", fake_discover)
     result = network_map.network_map("10.0.0.0/24")
-    assert result == ["10.0.0.1"]
+    assert result == [{"ip": "10.0.0.1"}]
     assert calls["subnet"] == "10.0.0.0/24"
 
 
 def test_network_map_success(monkeypatch, capsys):
     """JSON output and success log are emitted on success."""
 
-    monkeypatch.setattr(network_map, "discover_hosts", lambda subnet: ["192.168.0.10"])
+    monkeypatch.setattr(network_map, "discover_hosts", lambda subnet: [{"ip": "192.168.0.10"}])
     exit_code = network_map.main(["192.168.0.0/24"])
     captured = capsys.readouterr()
     assert exit_code == 0
     out_lines = captured.out.strip().splitlines()
-    assert json.loads(out_lines[0]) == ["192.168.0.10"]
+    assert json.loads(out_lines[0]) == [{"ip": "192.168.0.10"}]
     assert "succeeded" in out_lines[1]
     assert captured.err == ""
 


### PR DESCRIPTION
## Summary
- extend `discover_hosts` scan to resolve hostnames via nbtscan/avahi and query vendors using local OUI or macvendors API
- update topology builder and network map tests for new host structure
- verify discovered hosts include hostname and vendor information
- add test ensuring vendor resolution prefers local `oui.txt` over external API

## Testing
- `bash codex_run_tests.sh` *(fails: fastapi が無いので Codex/Windows では pytest 全体を skip)*

------
https://chatgpt.com/codex/tasks/task_e_68a8885d84f48323951a45c5d8d8e493