### PR TITLE
test: disable static scan button while loading

### DIFF
--- a/nw_checker/test/static_scan_tab_test.dart
+++ b/nw_checker/test/static_scan_tab_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nw_checker/static_scan_tab.dart';
@@ -68,10 +70,7 @@ void main() {
 
   testWidgets('shows placeholder when no findings', (tester) async {
     Future<Map<String, dynamic>> mockFetch() async {
-      return {
-        'risk_score': 0,
-        'findings': [],
-      };
+      return {'risk_score': 0, 'findings': []};
     }
 
     await tester.pumpWidget(
@@ -85,5 +84,41 @@ void main() {
 
     expect(find.text('結果なし'), findsOneWidget);
     expect(find.textContaining('リスクスコア'), findsNothing);
+  });
+
+  testWidgets('disables button while loading', (tester) async {
+    final completer = Completer<Map<String, dynamic>>();
+    var calls = 0;
+
+    Future<Map<String, dynamic>> mockFetch() {
+      calls++;
+      return completer.future;
+    }
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(body: StaticScanTab(fetcher: mockFetch)),
+      ),
+    );
+
+    final button = find.byKey(const Key('staticButton'));
+
+    await tester.tap(button);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 1));
+
+    // Second tap should be ignored while still loading.
+    await tester.tap(button);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 1));
+    expect(calls, 1);
+
+    completer.complete({'risk_score': 0, 'findings': []});
+    await tester.pumpAndSettle();
+
+    await tester.tap(button);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 1));
+    expect(calls, 2);
   });
 }

--- a/nw_checker/test/static_scan_tab_test.dart
+++ b/nw_checker/test/static_scan_tab_test.dart
@@ -103,11 +103,17 @@ void main() {
 
     final button = find.byKey(const Key('staticButton'));
 
+    // ボタンが初期状態で有効か確認
+    expect(tester.widget<ElevatedButton>(button).onPressed, isNotNull);
+
     await tester.tap(button);
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 1));
 
-    // Second tap should be ignored while still loading.
+    // 読み込み中はボタンが無効化されている
+    expect(tester.widget<ElevatedButton>(button).onPressed, isNull);
+
+    // 読み込み中に再度タップしても呼び出し回数は増えない
     await tester.tap(button);
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 1));
@@ -115,6 +121,9 @@ void main() {
 
     completer.complete({'risk_score': 0, 'findings': []});
     await tester.pumpAndSettle();
+
+    // 完了後はボタンが再び有効になる
+    expect(tester.widget<ElevatedButton>(button).onPressed, isNotNull);
 
     await tester.tap(button);
     await tester.pump();


### PR DESCRIPTION
## Summary
- add widget test verifying scan button is disabled during loading and re-enables after completion

## Testing
- `flutter test test/static_scan_tab_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_68a88d6b8c7c832389bba8dee2e526e8