### PR TITLE
Add SNMP-aware topology path builder

### DIFF
--- a/tests/test_topology_builder.py
+++ b/tests/test_topology_builder.py
@@ -1,60 +1,89 @@
-"""Tests for :mod:`topology_builder`."""
+"""Tests for building topology paths."""
 
 import json
 
-from src.topology_builder import build_topology, build_topology_for_subnet
+from src.topology_builder import build_paths, build_topology, build_topology_for_subnet
 
 
-def test_build_topology_basic(monkeypatch):
-    def fake_traceroute(ip):
-        return (
-            f"traceroute to {ip} ({ip}), 30 hops max\n"
-            "1  192.168.0.1  1.0 ms\n"
-            f"2  {ip}  2.0 ms\n"
-        )
-
-    monkeypatch.setattr("src.topology_builder._run_traceroute", lambda ip: fake_traceroute(ip))
-    monkeypatch.setattr("src.topology_builder._get_lldp_neighbors", lambda ip, community="public": [])
-
-    result = json.loads(build_topology(["192.168.0.10"]))
-    assert result == {"paths": [["LAN", "Router", "Host"]]}
+def _traceroute_output(ip: str) -> str:
+    return (
+        f"traceroute to {ip} ({ip}), 30 hops max\n"
+        "1  192.168.0.1  1.0 ms\n"
+        f"2  {ip}  2.0 ms\n"
+    )
 
 
-def test_build_topology_with_snmp(monkeypatch):
-    def fake_traceroute(ip):
-        return (
-            f"traceroute to {ip} ({ip}), 30 hops max\n"
-            "1  192.168.0.1  1.0 ms\n"
-            f"2  {ip}  2.0 ms\n"
-        )
+def test_build_paths_basic(monkeypatch):
+    """Hop IPs are converted to generic labels when SNMP is disabled."""
+
+    def fake_check_output(cmd, text=True):
+        return _traceroute_output(cmd[-1])
+
+    monkeypatch.setattr("src.topology_builder.subprocess.check_output", fake_check_output)
+
+    result = build_paths(["192.168.0.10"])
+    assert result == {
+        "paths": [{"ip": "192.168.0.10", "path": ["LAN", "Router", "Host"]}]
+    }
+
+
+def test_build_paths_with_snmp(monkeypatch):
+    """SNMP neighbor names replace router labels when requested."""
+
+    def fake_check_output(cmd, text=True):
+        return _traceroute_output(cmd[-1])
 
     def fake_neighbors(ip, community="public"):
         return ["SwitchA"] if ip == "192.168.0.1" else []
 
-    monkeypatch.setattr("src.topology_builder._run_traceroute", lambda ip: fake_traceroute(ip))
+    monkeypatch.setattr("src.topology_builder.subprocess.check_output", fake_check_output)
     monkeypatch.setattr("src.topology_builder._get_lldp_neighbors", fake_neighbors)
+    monkeypatch.setattr("src.topology_builder.nextCmd", object())
 
-    result = json.loads(build_topology(["192.168.0.20"], use_snmp=True))
-    assert result == {"paths": [["LAN", "SwitchA", "Host"]]}
+    result = build_paths(["192.168.0.20"], use_snmp=True)
+    assert result == {
+        "paths": [{"ip": "192.168.0.20", "path": ["LAN", "SwitchA", "Host"]}]
+    }
+
+
+def test_build_paths_snmp_unavailable(monkeypatch):
+    """Paths stay generic when pysnmp is missing."""
+
+    def fake_check_output(cmd, text=True):
+        return _traceroute_output(cmd[-1])
+
+    monkeypatch.setattr("src.topology_builder.subprocess.check_output", fake_check_output)
+    monkeypatch.setattr("src.topology_builder.nextCmd", None)
+
+    result = build_paths(["192.168.0.30"], use_snmp=True)
+    assert result["paths"][0]["path"] == ["LAN", "Router", "Host"]
+
+
+def test_build_topology_wrapper(monkeypatch):
+    """JSON wrapper returns only path arrays."""
+
+    def fake_check_output(cmd, text=True):
+        return _traceroute_output(cmd[-1])
+
+    monkeypatch.setattr("src.topology_builder.subprocess.check_output", fake_check_output)
+
+    data = json.loads(build_topology(["192.168.0.40", "192.168.0.41"]))
+    assert data == {"paths": [["LAN", "Router", "Host"], ["LAN", "Router", "Host"]]}
 
 
 def test_build_topology_for_subnet(monkeypatch):
-    """`build_topology_for_subnet` uses discovery results."""
+    """Hosts are discovered before building topology."""
 
-    # Fake discovery returning two hosts
-    monkeypatch.setattr(
-        "src.topology_builder.discover_hosts.discover_hosts", lambda subnet: ["10.0.0.1", "10.0.0.2"]
-    )
+    def fake_discover(subnet):
+        assert subnet == "192.168.0.0/24"
+        return [{"ip": "192.168.0.50"}, {"ip": "192.168.0.51"}]
 
-    def fake_traceroute(ip):
-        return (
-            f"traceroute to {ip} ({ip}), 30 hops max\n"
-            "1  192.168.0.1  1.0 ms\n"
-            f"2  {ip}  2.0 ms\n"
-        )
+    def fake_check_output(cmd, text=True):
+        return _traceroute_output(cmd[-1])
 
-    monkeypatch.setattr("src.topology_builder._run_traceroute", lambda ip: fake_traceroute(ip))
-    monkeypatch.setattr("src.topology_builder._get_lldp_neighbors", lambda ip, community="public": [])
+    monkeypatch.setattr("src.discover_hosts.discover_hosts", fake_discover)
+    monkeypatch.setattr("src.topology_builder.subprocess.check_output", fake_check_output)
 
-    result = json.loads(build_topology_for_subnet("192.168.0.0/24"))
-    assert result == {"paths": [["LAN", "Router", "Host"], ["LAN", "Router", "Host"]]}
+    data = json.loads(build_topology_for_subnet("192.168.0.0/24"))
+    assert data == {"paths": [["LAN", "Router", "Host"], ["LAN", "Router", "Host"]]}
+


### PR DESCRIPTION
## Summary
- add `build_paths` for traceroute-based path construction
- optionally augment hop labels using LLDP via pysnmp
- test traceroute parsing and SNMP augmentation via mocks
- expand topology tests for SNMP absence, JSON wrapper, and subnet discovery

## Testing
- `pytest tests/test_topology_builder.py`
- `pytest` *(fails: missing httpx, graphviz, scapy, pypdf, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a93352e9988323b762c64cee7f2b16