### PR TITLE
feat: add static scan logging and resilience

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import time
 
 import httpx
@@ -65,6 +66,23 @@ def test_static_scan_non_dict(monkeypatch):
     assert data['risk_score'] is None
 
 
+def test_static_scan_none(monkeypatch):
+    """run_allがNoneを返した場合のハンドリングを確認"""
+
+    def none_run_all():
+        return None
+
+    monkeypatch.setattr(server.static_scan, 'run_all', none_run_all)
+    client = TestClient(server.app)
+
+    resp = client.get('/static_scan')
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data['status'] == 'ok'
+    assert data['findings'] is None
+    assert data['risk_score'] is None
+
+
 def test_static_scan_pdf_report(monkeypatch):
     """PDFレポート生成の呼び出しを確認"""
 
@@ -112,3 +130,52 @@ def test_static_scan_does_not_block_other_requests(monkeypatch):
     resp, elapsed = asyncio.run(make_requests())
     assert resp.status_code == 404
     assert elapsed < 0.1
+
+
+def test_static_scan_logs_success(monkeypatch, caplog):
+    """ログ出力（成功時）を確認"""
+
+    def fake_run_all():
+        return {}
+
+    monkeypatch.setattr(server.static_scan, 'run_all', fake_run_all)
+    client = TestClient(server.app)
+
+    with caplog.at_level(logging.INFO):
+        client.get('/static_scan')
+
+    assert 'Starting static scan' in caplog.text
+    assert 'Static scan completed' in caplog.text
+
+
+def test_static_scan_logs_timeout(monkeypatch, caplog):
+    """ログ出力（タイムアウト時）を確認"""
+
+    def slow_run_all():
+        time.sleep(0.2)
+
+    monkeypatch.setattr(server.static_scan, 'run_all', slow_run_all)
+    monkeypatch.setattr(server, 'STATIC_SCAN_TIMEOUT', 0.05)
+    client = TestClient(server.app)
+
+    with caplog.at_level(logging.INFO):
+        client.get('/static_scan')
+
+    assert 'Starting static scan' in caplog.text
+    assert 'Static scan timed out' in caplog.text
+
+
+def test_static_scan_logs_error(monkeypatch, caplog):
+    """ログ出力（エラー時）を確認"""
+
+    def bad_run_all():
+        raise RuntimeError('boom')
+
+    monkeypatch.setattr(server.static_scan, 'run_all', bad_run_all)
+    client = TestClient(server.app)
+
+    with caplog.at_level(logging.INFO):
+        client.get('/static_scan')
+
+    assert 'Starting static scan' in caplog.text
+    assert 'Static scan failed' in caplog.text


### PR DESCRIPTION
## Summary
- log start, timeout, failure, and completion for `/static_scan`
- cover `None` results from `static_scan.run_all`
- test `/static_scan` logging for success, timeout, and error cases

## Testing
- `python -m pytest tests/test_server.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a93e0e88808323931eab1d26770b65