### PR TITLE
Add DNS history endpoint and caching

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -170,6 +170,25 @@ async def get_history_v2(
     return await get_history(start, end, device, protocol)
 
 
+@app.get("/scan/dynamic/dns-history")
+async def get_dns_history(start: str = Query(...), end: str = Query(...)):
+    return {
+        "results": scan_scheduler.storage.fetch_dns_history(start, end)
+    }
+
+
+@app.get("/dynamic-scan/dns-history")
+async def get_dns_history_v2(start: str = Query(...), end: str = Query(...)):
+    """動的スキャン DNS 履歴取得エイリアス"""
+    return await get_dns_history(start, end)
+
+
+@app.get("/dynamic_scan/dns-history")
+async def get_dns_history_v3(start: str = Query(...), end: str = Query(...)):
+    """動的スキャン DNS 履歴取得エイリアス（アンダースコア形式）"""
+    return await get_dns_history_v2(start, end)
+
+
 @app.websocket("/ws/scan/dynamic")
 @app.websocket("/ws/dynamic-scan")
 async def ws_dynamic_scan(websocket: WebSocket):

--- a/src/dynamic_scan/dns_analyzer.py
+++ b/src/dynamic_scan/dns_analyzer.py
@@ -1,6 +1,6 @@
 import socket
-from pathlib import Path
-from typing import Dict, Optional, Callable, Tuple
+from typing import Callable, Dict, Optional, Tuple
+
 
 # DNS 逆引き結果のキャッシュ
 _dns_cache: Dict[str, str] = {}
@@ -26,12 +26,16 @@ def reverse_dns_lookup(
     gethostbyaddr: Optional[Callable[[str], Tuple[str, list[str], list[str]]]] = None,
 ) -> str | None:
     """IP アドレスの逆引きを行いキャッシュする"""
+    cached = _dns_cache.get(ip_addr)
+    if cached:
+        return cached
+
     gha = gethostbyaddr or socket.gethostbyaddr
     try:
         host, _, _ = gha(ip_addr)
         host = host.rstrip(".").lower()
-        _dns_cache[ip_addr] = host  # 成功時はキャッシュ
+        _dns_cache[ip_addr] = host
         return host
-    except Exception:
-        cached = _dns_cache.get(ip_addr)
-        return cached.rstrip(".").lower() if isinstance(cached, str) else None
+    except Exception:  # pragma: no cover - 解決不能時
+        return None
+


### PR DESCRIPTION
## Summary
- cache reverse DNS lookups and load domain blacklist
- expose DNS history via new REST endpoints
- test DNS history API

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a949ccb8bc832381fa0fcf72bda160