### PR TITLE
refactor: expose static scan api at lib root

### DIFF
--- a/nw_checker/lib/static_scan_api.dart
+++ b/nw_checker/lib/static_scan_api.dart
@@ -1,5 +1,5 @@
 import 'dart:convert';
-import '../api_config.dart';
+import 'api_config.dart';
 import 'package:http/http.dart' as http;
 
 /// 静的スキャンAPIへの通信を担当するサービス。

--- a/nw_checker/lib/static_scan_tab.dart
+++ b/nw_checker/lib/static_scan_tab.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'services/static_scan_api.dart';
+import 'static_scan_api.dart';
 
 /// 静的スキャンタブ。
 /// ボタン押下で `/static_scan` を呼び出し結果を表示する。

--- a/nw_checker/test/static_scan_api_test.dart
+++ b/nw_checker/test/static_scan_api_test.dart
@@ -3,7 +3,7 @@ import 'dart:async';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
-import 'package:nw_checker/services/static_scan_api.dart';
+import 'package:nw_checker/static_scan_api.dart';
 
 void main() {
   test('fetchScan returns findings and score', () async {


### PR DESCRIPTION
## Summary
- move StaticScanApi to lib root for direct access
- update static scan tab and tests to import new location

## Testing
- `pytest`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_68a949c286548323959e7a1aefa23173