### PR TITLE
Add traceroute and SNMP path builder tests

### DIFF
--- a/tests/test_topology_builder.py
+++ b/tests/test_topology_builder.py
@@ -1,42 +1,55 @@
 """Tests for building topology paths."""
 
-from src.topology_builder import build_paths
+from src.topology_builder import build_paths, traceroute
 
 
-def _traceroute_output(ip: str) -> str:
-    return (
-        f"traceroute to {ip} ({ip}), 30 hops max\n"
-        "1  192.168.0.1  1.0 ms\n"
-        f"2  {ip}  2.0 ms\n"
-    )
+def test_traceroute_parses_hops(monkeypatch):
+    """Raw traceroute output is parsed into hop IP addresses."""
+
+    def fake_check_output(cmd, text=True):  # pragma: no cover - called via traceroute
+        return (
+            "traceroute to 8.8.8.8 (8.8.8.8), 30 hops max\n"
+            "1  192.168.0.1  1.0 ms\n"
+            "2  8.8.8.8  2.0 ms\n"
+        )
+
+    monkeypatch.setattr("src.topology_builder.subprocess.check_output", fake_check_output)
+
+    assert traceroute("8.8.8.8") == ["192.168.0.1", "8.8.8.8"]
 
 
 def test_build_paths_basic(monkeypatch):
     """Hop IPs are converted to generic labels when SNMP is disabled."""
 
-    def fake_check_output(cmd, text=True):
-        return _traceroute_output(cmd[-1])
+    def fake_traceroute(ip):  # pragma: no cover - simple stub
+        return ["192.168.0.1", ip]
 
-    monkeypatch.setattr("src.topology_builder.subprocess.check_output", fake_check_output)
+    called = {"flag": False}
+
+    def fake_augment(hops, path, community="public"):
+        called["flag"] = True
+
+    monkeypatch.setattr("src.topology_builder.traceroute", fake_traceroute)
+    monkeypatch.setattr("src.topology_builder._augment_with_snmp", fake_augment)
 
     result = build_paths(["192.168.0.10"])
     assert result == {
         "paths": [{"ip": "192.168.0.10", "path": ["LAN", "Router", "Host"]}]
     }
+    assert not called["flag"]
 
 
 def test_build_paths_with_snmp(monkeypatch):
     """SNMP neighbor names replace router labels when requested."""
 
-    def fake_check_output(cmd, text=True):
-        return _traceroute_output(cmd[-1])
+    def fake_traceroute(ip):  # pragma: no cover - simple stub
+        return ["192.168.0.1", ip]
 
-    def fake_neighbors(ip, community="public"):
-        return ["SwitchA"] if ip == "192.168.0.1" else []
+    def fake_augment(hops, path, community="public"):
+        path[1] = "SwitchA"
 
-    monkeypatch.setattr("src.topology_builder.subprocess.check_output", fake_check_output)
-    monkeypatch.setattr("src.topology_builder._get_lldp_neighbors", fake_neighbors)
-    monkeypatch.setattr("src.topology_builder.nextCmd", object())
+    monkeypatch.setattr("src.topology_builder.traceroute", fake_traceroute)
+    monkeypatch.setattr("src.topology_builder._augment_with_snmp", fake_augment)
 
     result = build_paths(["192.168.0.20"], use_snmp=True)
     assert result == {


### PR DESCRIPTION
## Summary
- test traceroute output parsing into hop IPs
- ensure build_paths uses traceroute and optionally augments via SNMP

## Testing
- `pytest tests/test_topology_builder.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a94b6447488323913e6fa841fa65bd