### PR TITLE
refactor: expose static scan api at lib root

### DIFF
--- a/nw_checker/lib/static_scan_api.dart
+++ b/nw_checker/lib/static_scan_api.dart
@@ -1,5 +1,5 @@
 import 'dart:convert';
-import '../api_config.dart';
+import 'api_config.dart';
 import 'package:http/http.dart' as http;
 
 /// 静的スキャンAPIへの通信を担当するサービス。

--- a/nw_checker/lib/static_scan_tab.dart
+++ b/nw_checker/lib/static_scan_tab.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'services/static_scan_api.dart';
+import 'static_scan_api.dart';
 
 /// 静的スキャンタブ。
 /// ボタン押下で `/static_scan` を呼び出し結果を表示する。

--- a/nw_checker/test/static_scan_api_test.dart
+++ b/nw_checker/test/static_scan_api_test.dart
@@ -3,7 +3,7 @@ import 'dart:async';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
-import 'package:nw_checker/services/static_scan_api.dart';
+import 'package:nw_checker/static_scan_api.dart';
 
 void main() {
   test('fetchScan returns findings and score', () async {
@@ -47,6 +47,16 @@ void main() {
       throwsA(isA<Exception>().having((e) => e.toString(), 'message', contains('bad'))),
     );
   });
+  test('fetchScan reports HTTP code when unknown error format', () async {
+    final client = MockClient((request) async {
+      return http.Response('whatever', 418);
+    });
+    expect(
+      StaticScanApi.fetchScan(client: client),
+      throwsA(isA<Exception>().having((e) => e.toString(), 'message', contains('HTTP 418'))),
+    );
+  });
+
 
   test('fetchScan throws on timeout', () async {
     final client = MockClient((request) async {

--- a/nw_checker/test/static_scan_tab_test.dart
+++ b/nw_checker/test/static_scan_tab_test.dart
@@ -85,7 +85,6 @@ void main() {
     expect(find.text('結果なし'), findsOneWidget);
     expect(find.textContaining('リスクスコア'), findsNothing);
   });
-
   testWidgets('disables button while loading', (tester) async {
     final completer = Completer<Map<String, dynamic>>();
     var calls = 0;
@@ -129,5 +128,26 @@ void main() {
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 1));
     expect(calls, 2);
+  });
+  testWidgets('defaults risk score to 0 when missing', (tester) async {
+    Future<Map<String, dynamic>> mockFetch() async {
+      return {
+        'findings': [
+          {'category': 'c', 'score': 1},
+        ],
+      };
+    }
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(body: StaticScanTab(fetcher: mockFetch)),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('staticButton')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('リスクスコア: 0'), findsOneWidget);
+    expect(find.text('c'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- move StaticScanApi to lib root for direct access
- update static scan tab and tests to import new location
- add coverage for API error reporting and default risk score behaviour

## Testing
- `pytest`
- `/root/flutter/bin/flutter test`


------
https://chatgpt.com/codex/tasks/task_e_68a949c286548323959e7a1aefa23173