### PR TITLE
Add reverse DNS caching and DNS history UI

### DIFF
--- a/nw_checker/lib/history_page.dart
+++ b/nw_checker/lib/history_page.dart
@@ -13,6 +13,7 @@ class _HistoryPageState extends State<HistoryPage> {
   final _fromController = TextEditingController();
   final _toController = TextEditingController();
   List<String> _results = [];
+  List<String> _dnsHistory = [];
   bool _loading = false;
 
   Future<void> _load() async {
@@ -21,8 +22,10 @@ class _HistoryPageState extends State<HistoryPage> {
       final from = DateTime.parse(_fromController.text);
       final to = DateTime.parse(_toController.text);
       _results = await DynamicScanApi.fetchHistory(from, to);
+      _dnsHistory = await DynamicScanApi.fetchDnsHistory(from, to);
     } catch (_) {
       _results = [];
+      _dnsHistory = [];
     }
     if (mounted) {
       setState(() => _loading = false);
@@ -58,9 +61,12 @@ class _HistoryPageState extends State<HistoryPage> {
               child: CircularProgressIndicator(),
             ),
             Expanded(
-              child: ListView.builder(
-                itemCount: _results.length,
-                itemBuilder: (context, index) => ListTile(title: Text(_results[index])),
+              child: ListView(
+                children: [
+                  ..._results.map((r) => ListTile(title: Text(r))),
+                  const Divider(),
+                  ..._dnsHistory.map((d) => ListTile(title: Text(d))),
+                ],
               ),
             ),
           ],

--- a/nw_checker/lib/services/dynamic_scan_api.dart
+++ b/nw_checker/lib/services/dynamic_scan_api.dart
@@ -105,6 +105,29 @@ class DynamicScanApi {
     return ['History ${from.toIso8601String()} - ${to.toIso8601String()}'];
   }
 
+  /// 指定期間のDNS履歴を取得する。
+  static Future<List<String>> fetchDnsHistory(DateTime from, DateTime to) async {
+    try {
+      final resp = await http.get(
+        Uri.parse(
+          '$_baseUrl/dynamic-scan/dns-history?start=${from.toIso8601String()}&end=${to.toIso8601String()}',
+        ),
+        headers: _headers(),
+      );
+      if (resp.statusCode == 200) {
+        final decoded = jsonDecode(resp.body) as Map<String, dynamic>;
+        final results = decoded['history'];
+        if (results is List) {
+          return results.cast<String>();
+        }
+      }
+    } catch (_) {}
+    await Future.delayed(const Duration(milliseconds: 300));
+    return [
+      'DNS History ${from.toIso8601String()} - ${to.toIso8601String()}',
+    ];
+  }
+
   /// アラート通知を購読する。
   /// 現状は2秒毎に2件のダミーアラートを流す。
   /// 実装済みの `/ws/dynamic-scan` WebSocket が利用可能になれば置き換え予定。

--- a/nw_checker/test/dynamic_scan_api_test.dart
+++ b/nw_checker/test/dynamic_scan_api_test.dart
@@ -24,4 +24,13 @@ void main() {
     expect(alerts.first, contains('ALERT'));
     expect(alerts, hasLength(2));
   });
+
+  test('fetchDnsHistory returns entries', () async {
+    final hist = await DynamicScanApi.fetchDnsHistory(
+      DateTime(2025, 1, 1),
+      DateTime(2025, 1, 2),
+    );
+    expect(hist, isNotEmpty);
+    expect(hist.first, contains('DNS History'));
+  });
 }

--- a/nw_checker/test/history_page_test.dart
+++ b/nw_checker/test/history_page_test.dart
@@ -9,10 +9,16 @@ void main() {
     await tester.enterText(find.byKey(const Key('toField')), '2025-01-02');
     await tester.tap(find.byKey(const Key('loadButton')));
     await tester.pump();
-    await tester.pump(const Duration(milliseconds: 300));
+    await tester.pump(const Duration(milliseconds: 600));
     expect(
       find.text(
         'History 2025-01-01T00:00:00.000 - 2025-01-02T00:00:00.000',
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.text(
+        'DNS History 2025-01-01T00:00:00.000 - 2025-01-02T00:00:00.000',
       ),
       findsOneWidget,
     );

--- a/src/dynamic_scan/analyze.py
+++ b/src/dynamic_scan/analyze.py
@@ -186,8 +186,7 @@ def record_dns_history(packet) -> AnalysisResult:
     src_ip = getattr(packet, "src_ip", getattr(packet, "ip_src", None))
     if not src_ip:
         return AnalysisResult()
-    hostname = reverse_dns_lookup(src_ip)
-    blacklisted = hostname in DNS_BLACKLIST if hostname else None
+    hostname, blacklisted = reverse_dns_lookup(src_ip)
     return AnalysisResult(reverse_dns=hostname, reverse_dns_blacklisted=blacklisted)
 
 

--- a/tests/test_dynamic_scan.py
+++ b/tests/test_dynamic_scan.py
@@ -35,7 +35,7 @@ def test_reverse_dns_lookup(monkeypatch):
     monkeypatch.setattr(
         analyze.socket, "gethostbyaddr", lambda ip: ("host.example", [], [])
     )
-    assert analyze.reverse_dns_lookup("1.1.1.1") == "host.example"
+    assert analyze.reverse_dns_lookup("1.1.1.1") == ("host.example", False)
 
 
 def test_is_dangerous_protocol():
@@ -116,7 +116,7 @@ def test_analyse_packets_pipeline(tmp_path, monkeypatch):
 
         monkeypatch.setattr(analyze, "geoip_lookup", fake_geoip)
         monkeypatch.setattr(geoip, "get_country", lambda ip: "CN")
-        monkeypatch.setattr(analyze, "reverse_dns_lookup", lambda ip: "example.com")
+        monkeypatch.setattr(analyze, "reverse_dns_lookup", lambda ip: ("example.com", False))
         queue: asyncio.Queue = asyncio.Queue()
         task = asyncio.create_task(
             analyze.analyse_packets(
@@ -169,7 +169,7 @@ def test_analyse_packets_pipeline_in_hours(tmp_path, monkeypatch):
 
         monkeypatch.setattr(analyze, "geoip_lookup", fake_geoip)
         monkeypatch.setattr(geoip, "get_country", lambda ip: "US")
-        monkeypatch.setattr(analyze, "reverse_dns_lookup", lambda ip: "example.com")
+        monkeypatch.setattr(analyze, "reverse_dns_lookup", lambda ip: ("example.com", False))
         queue: asyncio.Queue = asyncio.Queue()
         task = asyncio.create_task(
             analyze.analyse_packets(

--- a/tests/test_dynamic_scan_dns_analyzer.py
+++ b/tests/test_dynamic_scan_dns_analyzer.py
@@ -15,16 +15,22 @@ def test_reverse_dns_lookup_caches_and_reuses_result():
     def fake_gethostbyaddr(ip):
         return ("Host.Example.", [], [])
 
-    host = dns_analyzer.reverse_dns_lookup("1.1.1.1", gethostbyaddr=fake_gethostbyaddr)
+    host, blacklisted = dns_analyzer.reverse_dns_lookup(
+        "1.1.1.1", gethostbyaddr=fake_gethostbyaddr
+    )
     assert host == "host.example"
-    assert dns_analyzer._dns_cache["1.1.1.1"] == "host.example"
+    assert blacklisted is False
+    assert dns_analyzer._dns_cache["1.1.1.1"] == ("host.example", False)
 
     def failing(_):
         raise RuntimeError("network down")
 
     # キャッシュされた結果が返るため例外は表に出ない
-    cached = dns_analyzer.reverse_dns_lookup("1.1.1.1", gethostbyaddr=failing)
-    assert cached == "host.example"
+    cached_host, cached_bl = dns_analyzer.reverse_dns_lookup(
+        "1.1.1.1", gethostbyaddr=failing
+    )
+    assert cached_host == "host.example"
+    assert cached_bl is False
 
 
 def test_reverse_dns_lookup_failure_without_cache():
@@ -33,4 +39,21 @@ def test_reverse_dns_lookup_failure_without_cache():
     def failing(_):
         raise RuntimeError("network down")
 
-    assert dns_analyzer.reverse_dns_lookup("2.2.2.2", gethostbyaddr=failing) is None
+    assert dns_analyzer.reverse_dns_lookup("2.2.2.2", gethostbyaddr=failing) == (
+        None,
+        None,
+    )
+
+
+def test_reverse_dns_lookup_blacklisted():
+    dns_analyzer._dns_cache.clear()
+    dns_analyzer.DOMAIN_BLACKLIST.add("bad.example")
+
+    def fake_gethostbyaddr(_):
+        return ("bad.example", [], [])
+
+    host, blacklisted = dns_analyzer.reverse_dns_lookup(
+        "3.3.3.3", gethostbyaddr=fake_gethostbyaddr
+    )
+    assert host == "bad.example"
+    assert blacklisted is True


### PR DESCRIPTION
## Summary
- cache reverse DNS lookups and track blacklist status
- record DNS history in analysis and expose DNS history API
- show DNS history in Flutter history page

## Testing
- `pytest` *(fails: fastapi が無いので Codex/Windows では pytest 全体を skip)*
- `cd nw_checker && flutter test`

------
https://chatgpt.com/codex/tasks/task_e_68ad700c707083238ca406f9d5f6976a