### PR TITLE
Use pluggable socket for reverse DNS lookup

### DIFF
--- a/src/dynamic_scan/analyze.py
+++ b/src/dynamic_scan/analyze.py
@@ -32,8 +32,13 @@ DANGEROUS_COUNTRIES = load_dangerous_countries()
 
 load_blacklist = dns_analyzer.load_blacklist
 DNS_BLACKLIST = dns_analyzer.DOMAIN_BLACKLIST
-reverse_dns_lookup = dns_analyzer.reverse_dns_lookup
 socket = dns_analyzer.socket
+
+
+def reverse_dns_lookup(ip_addr: str):
+    return dns_analyzer.reverse_dns_lookup(
+        ip_addr, gethostbyaddr=socket.gethostbyaddr
+    )
 
 CONFIG_PATH = Path(__file__).with_name("config.json")
 


### PR DESCRIPTION
## Summary
- wrap reverse DNS lookup to inject `socket.gethostbyaddr`
- keep `_dns_history` referencing `dns_analyzer._dns_cache`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae80844968832387ea10f11073a00b