### PR TITLE
feat: expose DNS history and reverse lookup cache

### DIFF
--- a/nw_checker/lib/history_page.dart
+++ b/nw_checker/lib/history_page.dart
@@ -20,7 +20,11 @@ class _HistoryPageState extends State<HistoryPage> {
     try {
       final from = DateTime.parse(_fromController.text);
       final to = DateTime.parse(_toController.text);
-      _results = await DynamicScanApi.fetchHistory(from, to);
+      final lists = await Future.wait([
+        DynamicScanApi.fetchHistory(from, to),
+        DynamicScanApi.fetchDnsHistory(from, to),
+      ]);
+      _results = [...lists[0], ...lists[1]];
     } catch (_) {
       _results = [];
     }

--- a/nw_checker/test/history_page_test.dart
+++ b/nw_checker/test/history_page_test.dart
@@ -16,5 +16,11 @@ void main() {
       ),
       findsOneWidget,
     );
+    expect(
+      find.text(
+        'DNS History 2025-01-01T00:00:00.000 - 2025-01-02T00:00:00.000',
+      ),
+      findsOneWidget,
+    );
   });
 }

--- a/src/api.py
+++ b/src/api.py
@@ -170,6 +170,14 @@ async def get_history_v2(
     return await get_history(start, end, device, protocol)
 
 
+@app.get("/dynamic-scan/dns-history")
+async def get_dns_history(start: str, end: str):
+    """DNS 逆引き履歴を取得"""
+    return {
+        "history": scan_scheduler.storage.fetch_dns_history(start, end)
+    }
+
+
 @app.websocket("/ws/scan/dynamic")
 @app.websocket("/ws/dynamic-scan")
 async def ws_dynamic_scan(websocket: WebSocket):

--- a/src/dynamic_scan/analyze.py
+++ b/src/dynamic_scan/analyze.py
@@ -31,13 +31,12 @@ DANGEROUS_COUNTRIES = load_dangerous_countries()
 
 
 load_blacklist = dns_analyzer.load_blacklist
-DNS_BLACKLIST = dns_analyzer.DOMAIN_BLACKLIST
 socket = dns_analyzer.socket
 
 
 def reverse_dns_lookup(ip_addr: str):
     return dns_analyzer.reverse_dns_lookup(
-        ip_addr, gethostbyaddr=socket.gethostbyaddr
+        ip_addr, resolver=socket.gethostbyaddr
     )
 
 CONFIG_PATH = Path(__file__).with_name("config.json")
@@ -192,7 +191,7 @@ def record_dns_history(packet) -> AnalysisResult:
     if not src_ip:
         return AnalysisResult()
     hostname = reverse_dns_lookup(src_ip)
-    blacklisted = hostname in DNS_BLACKLIST if hostname else None
+    blacklisted = dns_analyzer.is_blacklisted(hostname) if hostname else None
     return AnalysisResult(reverse_dns=hostname, reverse_dns_blacklisted=blacklisted)
 
 

--- a/src/dynamic_scan/dns_analyzer.py
+++ b/src/dynamic_scan/dns_analyzer.py
@@ -1,42 +1,57 @@
 import socket
-from pathlib import Path
-from typing import Dict, Optional, Callable, Tuple
+import time
+from typing import Callable, Dict, Optional, Tuple
 
-# DNS 逆引き結果のキャッシュ
-_dns_cache: Dict[str, str] = {}
+# DNS 逆引き結果のキャッシュ {ip: (hostname, expire_at)}
+_dns_cache: Dict[str, Tuple[str, float]] = {}
 
 
 def load_blacklist(path: str = "configs/domain_blacklist.txt") -> set[str]:
     """ブラックリストファイルを読み込み"""
-    with open(path, encoding="utf-8") as f:
-        return {
-            line.strip().lower()
-            for line in f
-            if line.strip() and not line.startswith("#")
-        }
+    try:
+        with open(path, encoding="utf-8") as f:
+            return {
+                line.strip().lower()
+                for line in f
+                if line.strip() and not line.startswith("#")
+            }
+    except FileNotFoundError:
+        return set()
 
 
 # 逆引きドメインのブラックリスト
 DOMAIN_BLACKLIST = load_blacklist()
 
 
+def is_blacklisted(host: Optional[str]) -> bool:
+    """ドメインがブラックリストに含まれるか判定"""
+    if not host:
+        return False
+    return host.lower() in DOMAIN_BLACKLIST
+
+
 def reverse_dns_lookup(
     ip_addr: str,
     *,
-    gethostbyaddr: Optional[Callable[[str], Tuple[str, list[str], list[str]]]] = None,
+    resolver: Optional[Callable[[str], Tuple[str, list[str], list[str]]]] = None,
+    cache_ttl: int = 3600,
 ) -> str | None:
     """IP アドレスの逆引きを行いキャッシュする"""
 
-    # 既に逆引き済みならキャッシュを返す
+    now = time.time()
     cached = _dns_cache.get(ip_addr)
-    if isinstance(cached, str):
-        return cached
+    if cached:
+        host, expires_at = cached
+        if expires_at > now:
+            return host
+        del _dns_cache[ip_addr]
 
-    gha = gethostbyaddr or socket.gethostbyaddr
+    resolver = resolver or socket.gethostbyaddr
     try:
-        host, _, _ = gha(ip_addr)
+        host, _, _ = resolver(ip_addr)
         host = host.rstrip(".").lower()
-        _dns_cache[ip_addr] = host  # 成功時はキャッシュ
+        _dns_cache[ip_addr] = (host, now + cache_ttl)  # 成功時はキャッシュ
         return host
     except Exception:
         return None
+

--- a/src/dynamic_scan/dns_analyzer.py
+++ b/src/dynamic_scan/dns_analyzer.py
@@ -26,6 +26,12 @@ def reverse_dns_lookup(
     gethostbyaddr: Optional[Callable[[str], Tuple[str, list[str], list[str]]]] = None,
 ) -> str | None:
     """IP アドレスの逆引きを行いキャッシュする"""
+
+    # 既に逆引き済みならキャッシュを返す
+    cached = _dns_cache.get(ip_addr)
+    if isinstance(cached, str):
+        return cached
+
     gha = gethostbyaddr or socket.gethostbyaddr
     try:
         host, _, _ = gha(ip_addr)
@@ -33,5 +39,4 @@ def reverse_dns_lookup(
         _dns_cache[ip_addr] = host  # 成功時はキャッシュ
         return host
     except Exception:
-        cached = _dns_cache.get(ip_addr)
-        return cached.rstrip(".").lower() if isinstance(cached, str) else None
+        return None

--- a/tests/test_api_dns_history.py
+++ b/tests/test_api_dns_history.py
@@ -1,0 +1,26 @@
+import asyncio
+from fastapi.testclient import TestClient
+
+from src import api
+from src.dynamic_scan import scheduler, storage
+
+
+def test_dns_history_endpoint(tmp_path):
+    client = TestClient(api.app)
+    store = storage.Storage(tmp_path / "res.db")
+    sched = scheduler.DynamicScanScheduler()
+    sched.storage = store
+    api.scan_scheduler = sched
+
+    asyncio.run(store.save_dns_history("1.1.1.1", "host.example", False))
+    asyncio.run(store.save_dns_history("2.2.2.2", "bad.example", True))
+
+    resp = client.get(
+        "/dynamic-scan/dns-history",
+        params={"start": "1970-01-01", "end": "2100-01-01"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()["history"]
+    assert len(data) == 2
+    assert data[0]["hostname"] == "host.example"
+    assert data[1]["blacklisted"] is True

--- a/tests/test_dynamic_scan.py
+++ b/tests/test_dynamic_scan.py
@@ -32,6 +32,7 @@ def test_geoip_lookup(monkeypatch):
 
 
 def test_reverse_dns_lookup(monkeypatch):
+    analyze.dns_analyzer._dns_cache.clear()
     monkeypatch.setattr(
         analyze.socket, "gethostbyaddr", lambda ip: ("host.example", [], [])
     )

--- a/tests/test_dynamic_scan_dns_analyzer.py
+++ b/tests/test_dynamic_scan_dns_analyzer.py
@@ -12,18 +12,18 @@ def test_load_blacklist_ignores_comments_and_blank_lines(tmp_path):
 def test_reverse_dns_lookup_caches_and_reuses_result():
     dns_analyzer._dns_cache.clear()
 
-    def fake_gethostbyaddr(ip):
+    def fake_resolver(ip):
         return ("Host.Example.", [], [])
 
-    host = dns_analyzer.reverse_dns_lookup("1.1.1.1", gethostbyaddr=fake_gethostbyaddr)
+    host = dns_analyzer.reverse_dns_lookup("1.1.1.1", resolver=fake_resolver)
     assert host == "host.example"
-    assert dns_analyzer._dns_cache["1.1.1.1"] == "host.example"
+    assert dns_analyzer._dns_cache["1.1.1.1"][0] == "host.example"
 
     def failing(_):
         raise RuntimeError("network down")
 
     # キャッシュされた結果が返るため例外は表に出ない
-    cached = dns_analyzer.reverse_dns_lookup("1.1.1.1", gethostbyaddr=failing)
+    cached = dns_analyzer.reverse_dns_lookup("1.1.1.1", resolver=failing)
     assert cached == "host.example"
 
 
@@ -33,4 +33,39 @@ def test_reverse_dns_lookup_failure_without_cache():
     def failing(_):
         raise RuntimeError("network down")
 
-    assert dns_analyzer.reverse_dns_lookup("2.2.2.2", gethostbyaddr=failing) is None
+    assert dns_analyzer.reverse_dns_lookup("2.2.2.2", resolver=failing) is None
+
+
+def test_reverse_dns_lookup_cache_ttl(monkeypatch):
+    dns_analyzer._dns_cache.clear()
+    times = iter([0, 1, 7200])
+    monkeypatch.setattr(dns_analyzer.time, "time", lambda: next(times))
+
+    def first(ip):
+        return ("first.example", [], [])
+
+    def second(ip):
+        return ("second.example", [], [])
+
+    host1 = dns_analyzer.reverse_dns_lookup("1.1.1.1", resolver=first, cache_ttl=3600)
+    # TTL 内なのでキャッシュが利用され second は呼ばれない
+    host2 = dns_analyzer.reverse_dns_lookup("1.1.1.1", resolver=second, cache_ttl=3600)
+    assert host1 == host2 == "first.example"
+
+    # TTL 失効後は second の結果になる
+    host3 = dns_analyzer.reverse_dns_lookup("1.1.1.1", resolver=second, cache_ttl=3600)
+    assert host3 == "second.example"
+
+
+def test_is_blacklisted(monkeypatch, tmp_path):
+    file = tmp_path / "bl.txt"
+    file.write_text("bad.example\n")
+    bl = dns_analyzer.load_blacklist(str(file))
+    monkeypatch.setattr(dns_analyzer, "DOMAIN_BLACKLIST", bl, raising=False)
+    assert dns_analyzer.is_blacklisted("bad.example")
+    assert dns_analyzer.is_blacklisted("Bad.Example")
+    assert not dns_analyzer.is_blacklisted("good.example")
+
+
+def test_load_blacklist_missing_file(tmp_path):
+    assert dns_analyzer.load_blacklist(str(tmp_path / "none.txt")) == set()


### PR DESCRIPTION
## Summary
- cache reverse DNS lookups before querying again
- expose `/dynamic-scan/dns-history` API and wire Flutter History tab to display DNS results
- add tests for DNS history API and UI

## Testing
- `pytest` *(fails: fastapi missing, tests skipped)*
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_68aee63fe4b08323bab3324c3a116d21