### PR TITLE
Add port-based dangerous protocol detection with UI badge

### DIFF
--- a/nw_checker/lib/widgets/dynamic_scan_results.dart
+++ b/nw_checker/lib/widgets/dynamic_scan_results.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../models/scan_category.dart';
 import '../scan_result_detail_page.dart';
+import 'severity_badge.dart';
 
 /// 動的スキャン結果一覧ウィジェット。
 class DynamicScanResults extends StatelessWidget {
@@ -21,6 +22,7 @@ class DynamicScanResults extends StatelessWidget {
               .map(
                 (e) => ListTile(
                   title: Text(e),
+                  trailing: SeverityBadge(severity: cat.severity.name),
                   onTap: () {
                     Navigator.of(context).push(
                       MaterialPageRoute(

--- a/nw_checker/test/dynamic_scan_results_test.dart
+++ b/nw_checker/test/dynamic_scan_results_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nw_checker/models/scan_category.dart';
 import 'package:nw_checker/widgets/dynamic_scan_results.dart';
+import 'package:nw_checker/widgets/severity_badge.dart';
 
 void main() {
   testWidgets('DynamicScanResults expands categories and shows issues', (
@@ -19,5 +20,6 @@ void main() {
     await tester.tap(find.text('protocols'));
     await tester.pumpAndSettle();
     expect(find.text('ftp'), findsOneWidget);
+    expect(find.byType(SeverityBadge), findsOneWidget);
   });
 }

--- a/src/dynamic_scan/protocol_detector.py
+++ b/src/dynamic_scan/protocol_detector.py
@@ -1,0 +1,32 @@
+"""Protocol detection utilities.
+
+Defines dangerous ports and provides helpers to flag dangerous protocols
+based on source/destination port numbers.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+# Ports commonly associated with insecure or high-risk services
+DANGEROUS_PORTS: set[int] = {21, 23, 3389, 445}
+
+
+def is_dangerous_protocol(src_port: Any, dst_port: Any) -> bool:
+    """Return True if either port is considered dangerous.
+
+    Non-integer values are ignored.
+    """
+    ports = set()
+    for p in (src_port, dst_port):
+        if isinstance(p, int):
+            ports.add(p)
+    return any(p in DANGEROUS_PORTS for p in ports)
+
+
+def analyze_packet(pkt: Any) -> bool:
+    """Check packet ports and flag dangerous protocols."""
+    src_port = getattr(pkt, "src_port", getattr(pkt, "sport", None))
+    dst_port = getattr(pkt, "dst_port", getattr(pkt, "dport", None))
+    return is_dangerous_protocol(src_port, dst_port)


### PR DESCRIPTION
## Summary
- add protocol_detector module with high-risk ports and helpers
- flag dangerous protocols in analysis via port check
- show red severity badges for dangerous protocols in dynamic scan results

## Testing
- `pytest` *(fails: fastapi が無いので Codex/Windows では pytest 全体を skip)*
- `cd nw_checker && flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68aef0b2308c8323b5a3470996d16379