### PR TITLE
feat: flag dangerous protocols by port

### DIFF
--- a/nw_checker/lib/static_scan_api.dart
+++ b/nw_checker/lib/static_scan_api.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'api_config.dart';
 import 'package:http/http.dart' as http;
@@ -47,8 +48,11 @@ class StaticScanApi {
         return {'findings': findings, 'risk_score': riskScore};
       }
       throw Exception(_extractMessage(resp));
+    } on TimeoutException {
+      // タイムアウトは呼び出し元で明示的に扱えるよう再送出
+      rethrow;
     } catch (e) {
-      // 呼び出し元で処理できるようそのまま再スロー
+      // その他のエラーも呼び出し元に伝播
       rethrow;
     } finally {
       if (created) {

--- a/nw_checker/lib/widgets/dynamic_scan_results.dart
+++ b/nw_checker/lib/widgets/dynamic_scan_results.dart
@@ -25,7 +25,8 @@ class DynamicScanResults extends StatelessWidget {
                     children: [
                       SeverityBadge(severity: cat.severity.name),
                       const SizedBox(width: 8),
-                      Text(e),
+                      // 長いメッセージでも折り返せるようにする
+                      Expanded(child: Text(e)),
                     ],
                   ),
                   onTap: () {

--- a/nw_checker/lib/widgets/dynamic_scan_results.dart
+++ b/nw_checker/lib/widgets/dynamic_scan_results.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../models/scan_category.dart';
 import '../scan_result_detail_page.dart';
+import 'severity_badge.dart';
 
 /// 動的スキャン結果一覧ウィジェット。
 class DynamicScanResults extends StatelessWidget {
@@ -20,7 +21,13 @@ class DynamicScanResults extends StatelessWidget {
           children: cat.issues
               .map(
                 (e) => ListTile(
-                  title: Text(e),
+                  title: Row(
+                    children: [
+                      SeverityBadge(severity: cat.severity.name),
+                      const SizedBox(width: 8),
+                      Text(e),
+                    ],
+                  ),
                   onTap: () {
                     Navigator.of(context).push(
                       MaterialPageRoute(

--- a/nw_checker/test/dynamic_scan_results_test.dart
+++ b/nw_checker/test/dynamic_scan_results_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nw_checker/models/scan_category.dart';
 import 'package:nw_checker/widgets/dynamic_scan_results.dart';
+import 'package:nw_checker/widgets/severity_badge.dart';
 
 void main() {
   testWidgets('DynamicScanResults expands categories and shows issues', (
@@ -19,5 +20,8 @@ void main() {
     await tester.tap(find.text('protocols'));
     await tester.pumpAndSettle();
     expect(find.text('ftp'), findsOneWidget);
+    expect(find.byType(SeverityBadge), findsOneWidget);
+    final badge = tester.widget<SeverityBadge>(find.byType(SeverityBadge));
+    expect(badge.severity.toLowerCase(), 'high');
   });
 }

--- a/src/dynamic_scan/analyze.py
+++ b/src/dynamic_scan/analyze.py
@@ -7,11 +7,7 @@ from pathlib import Path
 from typing import Any, Dict, Iterable
 
 import httpx
-from . import geoip, dns_analyzer
-
-
-# 危険とされるプロトコルの名称
-DANGEROUS_PROTOCOLS = {"telnet", "ftp", "rdp"}
+from . import geoip, dns_analyzer, protocol_detector
 
 
 def load_dangerous_countries(
@@ -120,15 +116,6 @@ async def geoip_lookup(ip: str, db_path: str | None = None) -> Dict[str, Any]:
 
 
 
-def is_dangerous_protocol(protocol: str | None) -> bool:
-    """危険プロトコルか判定する。
-    文字列以外が渡された場合は危険ではないとみなす。
-    """
-    if not isinstance(protocol, str):
-        return False
-    return protocol.lower() in DANGEROUS_PROTOCOLS
-
-
 def is_unapproved_device(mac: str, approved_macs: Iterable[str]) -> bool:
     """未承認デバイス (MACアドレス) か判定する。"""
     return mac not in set(approved_macs)
@@ -200,7 +187,7 @@ def detect_dangerous_protocols(packet) -> AnalysisResult:
     protocol = getattr(
         packet, "protocol", getattr(getattr(packet, "payload", None), "name", "unknown")
     )
-    dangerous = is_dangerous_protocol(protocol)
+    dangerous = protocol_detector.analyze_packet(packet)
     return AnalysisResult(protocol=protocol, dangerous_protocol=dangerous)
 
 

--- a/src/dynamic_scan/analyze.py
+++ b/src/dynamic_scan/analyze.py
@@ -25,6 +25,10 @@ def load_dangerous_countries(
 # 危険国コードの集合
 DANGEROUS_COUNTRIES = load_dangerous_countries()
 
+# 危険プロトコル名の集合
+# ポート 21:FTP, 23:Telnet, 3389:RDP, 445:SMB など
+DANGEROUS_PROTOCOLS: set[str] = {"ftp", "telnet", "rdp", "smb"}
+
 
 load_blacklist = dns_analyzer.load_blacklist
 socket = dns_analyzer.socket

--- a/src/dynamic_scan/protocol_detector.py
+++ b/src/dynamic_scan/protocol_detector.py
@@ -1,0 +1,22 @@
+"""Protocol detection utilities for dynamic scanning.
+
+危険ポートの判定を行うモジュール。
+"""
+from typing import Optional
+
+# 危険とされるポート番号集合
+DANGEROUS_PORTS: set[int] = {21, 23, 3389, 445}
+
+
+def is_dangerous_protocol(src_port: Optional[int], dst_port: Optional[int]) -> bool:
+    """判断: 指定ポートが危険ポートか?"""
+    return any(
+        port in DANGEROUS_PORTS for port in (src_port, dst_port) if port is not None
+    )
+
+
+def analyze_packet(packet) -> bool:
+    """パケット内のポートを解析し危険プロトコルか判定する"""
+    src = getattr(packet, "src_port", getattr(packet, "sport", None))
+    dst = getattr(packet, "dst_port", getattr(packet, "dport", None))
+    return is_dangerous_protocol(src, dst)

--- a/tests/integration/test_dynamic_scan_flow.py
+++ b/tests/integration/test_dynamic_scan_flow.py
@@ -12,6 +12,7 @@ class DummyPacket:
     src_ip = "1.1.1.1"
     dst_ip = "2.2.2.2"
     protocol = "TELNET"
+    src_port = 23
     src_mac = "00:11:22:33:44:55"
     size = 100
     timestamp = 0.0

--- a/tests/test_api_dynamic_scan_alias.py
+++ b/tests/test_api_dynamic_scan_alias.py
@@ -6,6 +6,8 @@ from src.dynamic_scan import scheduler, storage, capture, analyze
 
 
 def test_dynamic_scan_start_stop_alias(monkeypatch, tmp_path):
+    # 認証トークンが設定されていると 401 になるため無効化
+    monkeypatch.setattr(api, "API_TOKEN", None, raising=False)
     client = TestClient(api.app)
     store = storage.Storage(tmp_path / "res.db")
     monkeypatch.setattr(storage, "Storage", lambda *args, **kwargs: store)
@@ -43,6 +45,7 @@ def test_dynamic_scan_start_stop_alias(monkeypatch, tmp_path):
 
 
 def test_dynamic_scan_results_alias(monkeypatch, tmp_path):
+    monkeypatch.setattr(api, "API_TOKEN", None, raising=False)
     client = TestClient(api.app)
     store = storage.Storage(tmp_path / "res.db")
     api.scan_scheduler = scheduler.DynamicScanScheduler()
@@ -59,6 +62,7 @@ def test_dynamic_scan_results_alias(monkeypatch, tmp_path):
 
 
 def test_dynamic_scan_ws_alias(monkeypatch):
+    monkeypatch.setattr(api, "API_TOKEN", None, raising=False)
     client = TestClient(api.app)
     holder: dict[str, asyncio.Queue] = {}
 

--- a/tests/test_api_dynamic_scan_underscore_alias.py
+++ b/tests/test_api_dynamic_scan_underscore_alias.py
@@ -6,6 +6,7 @@ from src.dynamic_scan import scheduler, storage, capture, analyze
 
 
 def test_dynamic_scan_start_stop_underscore_alias(monkeypatch, tmp_path):
+    monkeypatch.setattr(api, "API_TOKEN", None, raising=False)
     client = TestClient(api.app)
     store = storage.Storage(tmp_path / "res.db")
     monkeypatch.setattr(storage, "Storage", lambda *args, **kwargs: store)
@@ -43,6 +44,7 @@ def test_dynamic_scan_start_stop_underscore_alias(monkeypatch, tmp_path):
 
 
 def test_dynamic_scan_results_underscore_alias(monkeypatch, tmp_path):
+    monkeypatch.setattr(api, "API_TOKEN", None, raising=False)
     client = TestClient(api.app)
     store = storage.Storage(tmp_path / "res.db")
     api.scan_scheduler = scheduler.DynamicScanScheduler()

--- a/tests/test_dynamic_scan.py
+++ b/tests/test_dynamic_scan.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 
 import pytest
 
-from src.dynamic_scan import analyze, capture, storage, geoip
+from src.dynamic_scan import analyze, capture, storage, geoip, protocol_detector
 
 
 def test_geoip_lookup(monkeypatch):
@@ -40,13 +40,13 @@ def test_reverse_dns_lookup(monkeypatch):
 
 
 def test_is_dangerous_protocol():
-    assert analyze.is_dangerous_protocol("telnet")
-    assert not analyze.is_dangerous_protocol("http")
-    assert not analyze.is_dangerous_protocol(None)
+    assert protocol_detector.is_dangerous_protocol(23, 1000)
+    assert not protocol_detector.is_dangerous_protocol(80, 8080)
+    assert not protocol_detector.is_dangerous_protocol(None, None)
 
 
-def test_detect_dangerous_protocols_none():
-    pkt = SimpleNamespace(protocol=None)
+def test_detect_dangerous_protocols_safe_ports():
+    pkt = SimpleNamespace(protocol="HTTP", src_port=80, dst_port=8080)
     res = analyze.detect_dangerous_protocols(pkt)
     assert res.dangerous_protocol is False
 
@@ -132,6 +132,7 @@ def test_analyse_packets_pipeline(tmp_path, monkeypatch):
             dst_ip="1.1.1.1",
             src_mac="00:11:22:33:44:66",
             protocol="TELNET",
+            src_port=23,
             size=2_000_000,
             timestamp=datetime(2024, 1, 1, 2, 0, 0).timestamp(),
         )
@@ -185,6 +186,7 @@ def test_analyse_packets_pipeline_in_hours(tmp_path, monkeypatch):
             dst_ip="1.1.1.1",
             src_mac="00:11:22:33:44:77",
             protocol="TELNET",
+            src_port=23,
             size=2_000_000,
             timestamp=datetime(2024, 1, 1, 10, 0, 0).timestamp(),
         )

--- a/tests/test_dynamic_scan_analyze.py
+++ b/tests/test_dynamic_scan_analyze.py
@@ -10,7 +10,7 @@ from src.dynamic_scan import geoip
 
 import pytest
 
-from src.dynamic_scan import analyze, dns_analyzer
+from src.dynamic_scan import analyze, dns_analyzer, protocol_detector
 
 
 @pytest.fixture
@@ -257,9 +257,14 @@ def test_reverse_dns_lookup_cached(monkeypatch):
 
 
 def test_is_dangerous_protocol():
-    assert analyze.is_dangerous_protocol("telnet")
-    assert not analyze.is_dangerous_protocol("http")
-    assert not analyze.is_dangerous_protocol(None)
+    assert protocol_detector.is_dangerous_protocol(21, 80)
+    assert not protocol_detector.is_dangerous_protocol(80, 8080)
+    assert not protocol_detector.is_dangerous_protocol(None, None)
+
+
+def test_analyze_packet_helper():
+    pkt = type("Pkt", (), {"src_port": 445, "dst_port": 1})
+    assert protocol_detector.analyze_packet(pkt) is True
 
 
 def test_is_unapproved_device():
@@ -391,7 +396,7 @@ def test_record_dns_history(monkeypatch):
 
 
 def test_detect_dangerous_protocols():
-    pkt = type("Pkt", (), {"protocol": "TELNET"})
+    pkt = type("Pkt", (), {"protocol": "TELNET", "src_port": 23})
     res = analyze.detect_dangerous_protocols(pkt)
     assert res.dangerous_protocol is True
 
@@ -472,13 +477,13 @@ def test_record_dns_history_blacklisted_cached(monkeypatch):
 
 
 def test_detect_dangerous_protocols_safe_protocol():
-    pkt = type("Pkt", (), {"protocol": "HTTP"})
+    pkt = type("Pkt", (), {"protocol": "HTTP", "src_port": 80})
     res = analyze.detect_dangerous_protocols(pkt)
     assert res.dangerous_protocol is False
 
 
 def test_detect_dangerous_protocols_none_protocol():
-    pkt = type("Pkt", (), {"protocol": None})
+    pkt = type("Pkt", (), {})
     res = analyze.detect_dangerous_protocols(pkt)
     assert res.dangerous_protocol is False
 


### PR DESCRIPTION
## Summary
- detect dangerous protocols by matching common insecure ports
- expose dangerous protocol flag through analysis results
- show severity badge for dangerous protocol issues in UI

## Testing
- `pytest` *(fails: fastapi missing, tests skipped)*
- `flutter test` *(fails: dynamic_scan_tab_test shows DHCP warning)*

------
https://chatgpt.com/codex/tasks/task_e_68aef6ed712083239eb97f2f7b3bb666