### PR TITLE
Add FastAPI CI job and markers

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -1,0 +1,50 @@
+name: Python CI
+
+on:
+  push:
+    paths:
+      - '**.py'
+      - '.github/workflows/python-ci.yml'
+      - 'requirements*.txt'
+      - 'pytest.ini'
+      - 'codex_run_tests.sh'
+      - 'tests/**'
+  pull_request:
+    paths:
+      - '**.py'
+      - '.github/workflows/python-ci.yml'
+      - 'requirements*.txt'
+      - 'pytest.ini'
+      - 'codex_run_tests.sh'
+      - 'tests/**'
+
+jobs:
+  python-tests:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+      - name: Run tests
+        shell: bash
+        run: ./codex_run_tests.sh
+
+  python-fastapi-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+          pip install "fastapi[all]" uvicorn httpx pytest-asyncio
+      - name: Run FastAPI tests
+        run: pytest -m fastapi -vv

--- a/codex_run_tests.sh
+++ b/codex_run_tests.sh
@@ -12,7 +12,7 @@ which python || true
 echo "== PyTest =="
 # src が見えるように（pytest.ini でもOKだが念のため）
 export PYTHONPATH="$ROOT/src:${PYTHONPATH:-}"
-python -m pytest -q
+python -m pytest -m "not fastapi" -q
 
 # --- Flutter tests ---
 if [ -f "$ROOT/pubspec.yaml" ]; then

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,7 @@
 [pytest]
 testpaths = tests
 python_files = test_*.py
-markers = benchmark: performance benchmark
+markers =
+    benchmark: performance benchmark
+    fastapi: tests requiring FastAPI
 pythonpath = src

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,12 @@
-# tests/conftest.py
-import pytest
+"""pytest 共通設定."""
+
 import importlib.util
 
+
 def _has(mod: str) -> bool:
+    """Return True if the module can be imported."""
     return importlib.util.find_spec(mod) is not None
 
-# ここだけ全体skip（API層が無いとほぼ全部落ちるため）
-if not _has("fastapi"):
-    pytest.skip("fastapi が無いので Codex/Windows では pytest 全体を skip", allow_module_level=True)
 
 # 他の依存 (impacket, nmap, pysnmp など) は
 # 各テストファイルで pytest.importorskip() する

--- a/tests/integration/test_dynamic_scan_flow.py
+++ b/tests/integration/test_dynamic_scan_flow.py
@@ -2,10 +2,14 @@ import asyncio
 import tracemalloc
 from contextlib import suppress
 import pytest
+
+pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient
 
 from src import api
 from src.dynamic_scan import analyze, capture, storage, geoip
+
+pytestmark = pytest.mark.fastapi
 
 
 class DummyPacket:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,8 +1,13 @@
 import asyncio
+import pytest
+
+pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient
 
 from src import api
 from src.dynamic_scan import capture, analyze, storage, scheduler
+
+pytestmark = pytest.mark.fastapi
 
 
 def test_dynamic_scan_start_stop(monkeypatch, tmp_path):

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -1,7 +1,11 @@
 import pytest
+
+pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient
 
 from src import api
+
+pytestmark = pytest.mark.fastapi
 
 
 def test_auth_middleware_enforces_token(monkeypatch):

--- a/tests/test_api_dns_history.py
+++ b/tests/test_api_dns_history.py
@@ -1,8 +1,13 @@
 import asyncio
+import pytest
+
+pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient
 
 from src import api
 from src.dynamic_scan import scheduler, storage
+
+pytestmark = pytest.mark.fastapi
 
 
 def test_dns_history_endpoint(tmp_path):

--- a/tests/test_api_dynamic_scan.py
+++ b/tests/test_api_dynamic_scan.py
@@ -1,9 +1,13 @@
 import asyncio
 import pytest
+
+pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient
 
 from src import api
 from src.dynamic_scan import capture, analyze, storage, scheduler
+
+pytestmark = pytest.mark.fastapi
 
 @pytest.mark.parametrize("base", ["/scan/dynamic", "/dynamic-scan"])
 def test_dynamic_scan_endpoints(monkeypatch, tmp_path, base):

--- a/tests/test_api_dynamic_scan_alias.py
+++ b/tests/test_api_dynamic_scan_alias.py
@@ -1,8 +1,13 @@
 import asyncio
+import pytest
+
+pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient
 
 from src import api
 from src.dynamic_scan import scheduler, storage, capture, analyze
+
+pytestmark = pytest.mark.fastapi
 
 
 def test_dynamic_scan_start_stop_alias(monkeypatch, tmp_path):

--- a/tests/test_api_dynamic_scan_underscore_alias.py
+++ b/tests/test_api_dynamic_scan_underscore_alias.py
@@ -1,8 +1,13 @@
 import asyncio
+import pytest
+
+pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient
 
 from src import api
 from src.dynamic_scan import scheduler, storage, capture, analyze
+
+pytestmark = pytest.mark.fastapi
 
 
 def test_dynamic_scan_start_stop_underscore_alias(monkeypatch, tmp_path):

--- a/tests/test_api_health.py
+++ b/tests/test_api_health.py
@@ -1,5 +1,10 @@
+import pytest
+
+pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient
 from src.api import app   # ← あなたのFastAPIアプリのエントリポイントをimport
+
+pytestmark = pytest.mark.fastapi
 
 def test_health():
     client = TestClient(app)

--- a/tests/test_api_static_scan.py
+++ b/tests/test_api_static_scan.py
@@ -1,7 +1,11 @@
 import time
+import pytest
 
+pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient
 from src import server
+
+pytestmark = pytest.mark.fastapi
 
 
 def test_static_scan_success(monkeypatch):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,10 +1,15 @@
 import asyncio
 import logging
 import time
+import pytest
 
 import httpx
+
+pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient
 from src import server
+
+pytestmark = pytest.mark.fastapi
 
 
 def test_static_scan_success(monkeypatch):


### PR DESCRIPTION
## Summary
- add GitHub Actions job to run FastAPI tests on Ubuntu
- skip FastAPI tests in Windows/Codex job
- mark FastAPI-dependent tests and add fastapi marker

## Testing
- `pytest -m fastapi -vv`
- `pytest -m "not fastapi" -q`


------
https://chatgpt.com/codex/tasks/task_e_68af02e413a48323bb23dab747cf9f50