### PR TITLE
Use SNMP only when available in topology paths

### DIFF
--- a/src/topology_builder.py
+++ b/src/topology_builder.py
@@ -91,7 +91,7 @@ def build_paths(hosts: Iterable[str], use_snmp: bool = False, community: str = "
         path: List[str] = ["LAN"]
         for hop in hops:
             path.append("Host" if hop == ip else "Router")
-        if use_snmp:
+        if use_snmp and nextCmd is not None:
             _augment_with_snmp(hops, path, community)
         results.append({"ip": ip, "path": path})
     return {"paths": results}

--- a/tests/test_topology_builder.py
+++ b/tests/test_topology_builder.py
@@ -57,6 +57,7 @@ def test_build_paths_with_snmp(monkeypatch):
 
     monkeypatch.setattr("src.topology_builder.traceroute", fake_traceroute)
     monkeypatch.setattr("src.topology_builder._augment_with_snmp", fake_augment)
+    monkeypatch.setattr("src.topology_builder.nextCmd", object())
 
     result = build_paths(["192.168.0.20"], use_snmp=True)
     assert result == {
@@ -98,9 +99,11 @@ def test_build_topology_for_subnet(monkeypatch):
         captured["community"] = community
         return "JSON"
 
-    monkeypatch.setattr(
-        "src.discover_hosts.discover_hosts", fake_discover_hosts
-    )
+    import sys
+    import types
+
+    fake_module = types.SimpleNamespace(discover_hosts=fake_discover_hosts)
+    monkeypatch.setitem(sys.modules, "src.discover_hosts", fake_module)
     monkeypatch.setattr("src.topology_builder.build_topology", fake_build_topology)
 
     result = build_topology_for_subnet(


### PR DESCRIPTION
## Summary
- Guard SNMP augmentation by verifying pysnmp availability
- Mock SNMP presence and discovery in topology builder tests

## Testing
- `pytest tests/test_topology_builder.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'nmap', httpx, requests, scapy, apscheduler, graphviz, pypdf)*

------
https://chatgpt.com/codex/tasks/task_e_68afb194a1008323919a77a53b563937