### PR TITLE
ci: add codex shim preparation step

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -30,6 +30,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt -r requirements-dev.txt
+      - name: Prepare (Codex shim)
+        shell: bash
+        run: |
+          chmod +x ./codex_run_tests.sh
+          ./codex_run_tests.sh
       - name: Run tests
         shell: bash
         run: ./codex_run_tests.sh
@@ -46,5 +51,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt -r requirements-dev.txt
           pip install "fastapi[all]" uvicorn httpx pytest-asyncio
+      - name: Prepare (Codex shim)
+        shell: bash
+        run: |
+          chmod +x ./codex_run_tests.sh
+          ./codex_run_tests.sh
       - name: Run FastAPI tests
         run: pytest -m fastapi -vv


### PR DESCRIPTION
## Summary
- run `codex_run_tests.sh` in a dedicated "Prepare (Codex shim)" step for python and fastapi jobs

## Testing
- `python -m pytest tests/test_python_ci_workflow.py::test_python_ci_has_fastapi_job -q`


------
https://chatgpt.com/codex/tasks/task_e_68afbcb7cc608323822da988458847ec