### PR TITLE
chore: streamline CI checks

### DIFF
--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -1,64 +1,22 @@
 name: CI
+
 on:
   push:
+    paths:
+      - 'nw_checker/**'
+      - '.github/workflows/flutter-ci.yml'
   pull_request:
-  workflow_dispatch:
+    paths:
+      - 'nw_checker/**'
+      - '.github/workflows/flutter-ci.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  backend:
-    name: Python (pytest)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: System deps (for scapy etc.)
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libpcap-dev
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-          cache: 'pip'
-
-      - name: Check python files
-        id: check_py
-        run: |
-          if [ -f requirements.txt ]; then echo "req=true" >> "$GITHUB_OUTPUT"; else echo "req=false" >> "$GITHUB_OUTPUT"; fi
-          if git ls-files 'tests/**/*.py' >/dev/null 2>&1; then echo "tests=true" >> "$GITHUB_OUTPUT"; else echo "tests=false" >> "$GITHUB_OUTPUT"; fi
-
-      - name: Install deps
-        if: ${{ steps.check_py.outputs.req == 'true' }}
-        run: |
-          set -eux
-          python -m pip install -U pip
-          pip install -r requirements.txt
-          # dev依存（あれば）
-          if [ -f requirements-dev.txt ]; then cat requirements-dev.txt; pip install -r requirements-dev.txt; fi
-          # 念のため保険で明示インストール
-          pip install "fastapi==0.116.1" "starlette>=0.37" "httpx==0.28.1" "anyio>=3" "python-multipart>=0.0.9"
-          # 開発インストール（src解決用）
-          python -m pip install -e . || true
-
-      - name: Verify deps
-        if: ${{ steps.check_py.outputs.req == 'true' }}
-        run: |
-          python -c "import pkgutil;mods=['fastapi','starlette','httpx','anyio','multipart'];print('\n'.join([m+' '+('OK' if pkgutil.find_loader(m) else 'MISSING') for m in mods]))"
-          python -c "import fastapi,starlette;print('fastapi',fastapi.__version__);print('starlette',starlette.__version__)"
-
-      - name: Run pytest
-        if: ${{ steps.check_py.outputs.req == 'true' && steps.check_py.outputs.tests == 'true' }}
-        env:
-          PYTHONPATH: ${{ github.workspace }}
-        run: pytest -q
-
-      - name: Note when skipped
-        if: ${{ steps.check_py.outputs.req != 'true' || steps.check_py.outputs.tests != 'true' }}
-        run: |
-          echo 'Python: skipped (no requirements.txt or tests directory)'
-
   flutter:
-    name: Flutter tests
+    name: Flutter テスト
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -3,20 +3,24 @@ name: Python CI
 on:
   push:
     paths:
-      - '**.py'
-      - '.github/workflows/python-ci.yml'
+      - 'src/**'
+      - 'tests/**'
+      - 'pyproject.toml'
       - 'requirements*.txt'
       - 'pytest.ini'
-      - 'codex_run_tests.sh'
-      - 'tests/**'
+      - '.github/workflows/python-ci.yml'
   pull_request:
     paths:
-      - '**.py'
-      - '.github/workflows/python-ci.yml'
+      - 'src/**'
+      - 'tests/**'
+      - 'pyproject.toml'
       - 'requirements*.txt'
       - 'pytest.ini'
-      - 'codex_run_tests.sh'
-      - 'tests/**'
+      - '.github/workflows/python-ci.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   python-tests:
@@ -30,14 +34,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt -r requirements-dev.txt
-      - name: Prepare (Codex shim)
-        shell: bash
-        run: |
-          chmod +x ./codex_run_tests.sh
-          ./codex_run_tests.sh
       - name: Run tests
         shell: bash
-        run: ./codex_run_tests.sh
+        run: pytest -m "not fastapi" -vv
 
   python-fastapi-tests:
     runs-on: ubuntu-latest
@@ -51,10 +50,5 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt -r requirements-dev.txt
           pip install "fastapi[all]" uvicorn httpx pytest-asyncio
-      - name: Prepare (Codex shim)
-        shell: bash
-        run: |
-          chmod +x ./codex_run_tests.sh
-          ./codex_run_tests.sh
       - name: Run FastAPI tests
         run: pytest -m fastapi -vv

--- a/tests/test_python_ci_workflow.py
+++ b/tests/test_python_ci_workflow.py
@@ -5,6 +5,6 @@ def test_python_ci_has_fastapi_job():
     """python-ci workflow should include FastAPI test job"""
     workflow = Path('.github/workflows/python-ci.yml').read_text(encoding='utf-8')
     assert 'python-tests:' in workflow
+    assert 'pytest -m "not fastapi" -vv' in workflow
     assert 'python-fastapi-tests:' in workflow
     assert 'pytest -m fastapi -vv' in workflow
-    assert './codex_run_tests.sh' in workflow


### PR DESCRIPTION
## Summary
- drop legacy **CI / Python (pytest)** job
- run python tests separately for FastAPI and other suites
- keep only **CI / Flutter テスト** in flutter workflow

## Testing
- `pytest -m "not fastapi"`
- `pytest -m fastapi`
- `cd nw_checker && flutter test`

### Deleted job
- CI / Python (pytest)

### Required checks
- Python CI / python-tests
- Python CI / python-fastapi-tests
- CI / Flutter テスト

------
https://chatgpt.com/codex/tasks/task_e_68afdedb643483238f0f0984e02975fe