### PR TITLE
Ensure SNMP augmentation only when pysnmp available and add tests

### DIFF
--- a/src/topology_builder.py
+++ b/src/topology_builder.py
@@ -91,7 +91,7 @@ def build_paths(hosts: Iterable[str], use_snmp: bool = False, community: str = "
         path: List[str] = ["LAN"]
         for hop in hops:
             path.append("Host" if hop == ip else "Router")
-        if use_snmp:
+        if use_snmp and nextCmd is not None:
             _augment_with_snmp(hops, path, community)
         results.append({"ip": ip, "path": path})
     return {"paths": results}

--- a/test/test_topology_builder.py
+++ b/test/test_topology_builder.py
@@ -1,0 +1,59 @@
+"""Unit tests for topology builder utilities."""
+
+from src import topology_builder as tb
+
+
+def test_traceroute_parsing(monkeypatch):
+    """Traceroute output is parsed into hop IPs."""
+
+    def fake_check_output(cmd, text=True):  # pragma: no cover - simple mock
+        return (
+            "traceroute to 1.1.1.1 (1.1.1.1), 30 hops max\n"
+            "1  192.168.0.1  1.0 ms\n"
+            "2  1.1.1.1  2.0 ms\n"
+        )
+
+    monkeypatch.setattr(tb.subprocess, "check_output", fake_check_output)
+    assert tb.traceroute("1.1.1.1") == ["192.168.0.1", "1.1.1.1"]
+
+
+def test_build_paths_skips_snmp_when_unavailable(monkeypatch):
+    """_augment_with_snmp is skipped if pysnmp is missing."""
+
+    def fake_traceroute(ip):  # pragma: no cover - simple stub
+        return ["192.168.0.1", ip]
+
+    called = {"flag": False}
+
+    def fake_augment(hops, path, community="public"):
+        called["flag"] = True
+
+    monkeypatch.setattr(tb, "traceroute", fake_traceroute)
+    monkeypatch.setattr(tb, "_augment_with_snmp", fake_augment)
+    monkeypatch.setattr(tb, "nextCmd", None)
+
+    result = tb.build_paths(["192.168.0.5"], use_snmp=True)
+    assert result == {
+        "paths": [{"ip": "192.168.0.5", "path": ["LAN", "Router", "Host"]}]
+    }
+    assert not called["flag"]
+
+
+def test_build_paths_calls_snmp_when_available(monkeypatch):
+    """_augment_with_snmp is invoked when pysnmp is present."""
+
+    def fake_traceroute(ip):  # pragma: no cover - simple stub
+        return ["192.168.0.1", ip]
+
+    def fake_augment(hops, path, community="public"):
+        path[1] = "SwitchA"
+
+    monkeypatch.setattr(tb, "traceroute", fake_traceroute)
+    monkeypatch.setattr(tb, "_augment_with_snmp", fake_augment)
+    monkeypatch.setattr(tb, "nextCmd", object())
+
+    result = tb.build_paths(["192.168.0.6"], use_snmp=True)
+    assert result == {
+        "paths": [{"ip": "192.168.0.6", "path": ["LAN", "SwitchA", "Host"]}]
+    }
+

--- a/tests/test_topology_builder.py
+++ b/tests/test_topology_builder.py
@@ -57,6 +57,7 @@ def test_build_paths_with_snmp(monkeypatch):
 
     monkeypatch.setattr("src.topology_builder.traceroute", fake_traceroute)
     monkeypatch.setattr("src.topology_builder._augment_with_snmp", fake_augment)
+    monkeypatch.setattr("src.topology_builder.nextCmd", object())
 
     result = build_paths(["192.168.0.20"], use_snmp=True)
     assert result == {
@@ -98,9 +99,10 @@ def test_build_topology_for_subnet(monkeypatch):
         captured["community"] = community
         return "JSON"
 
-    monkeypatch.setattr(
-        "src.discover_hosts.discover_hosts", fake_discover_hosts
-    )
+    import sys, types
+
+    fake_module = types.SimpleNamespace(discover_hosts=fake_discover_hosts)
+    monkeypatch.setitem(sys.modules, "src.discover_hosts", fake_module)
     monkeypatch.setattr("src.topology_builder.build_topology", fake_build_topology)
 
     result = build_topology_for_subnet(


### PR DESCRIPTION
## Summary
- Gate SNMP path augmentation on pysnmp availability in `build_paths`
- Add unit tests for traceroute parsing and SNMP augmentation behaviour
- Adjust existing topology builder tests for new SNMP gating and stubbed discovery module

## Testing
- `pytest tests/test_topology_builder.py test/test_topology_builder.py -q`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_68afe0c3b1788323a6f37b3d25f2bb3b