### PR TITLE
feat: build topology paths with optional SNMP

### DIFF
--- a/src/topology_builder.py
+++ b/src/topology_builder.py
@@ -91,7 +91,7 @@ def build_paths(hosts: Iterable[str], use_snmp: bool = False, community: str = "
         path: List[str] = ["LAN"]
         for hop in hops:
             path.append("Host" if hop == ip else "Router")
-        if use_snmp:
+        if use_snmp and nextCmd is not None:
             _augment_with_snmp(hops, path, community)
         results.append({"ip": ip, "path": path})
     return {"paths": results}


### PR DESCRIPTION
## Summary
- map traceroute hops to labelled paths and augment with SNMP when available
- expand topology builder tests for traceroute parsing, SNMP presence/absence, and direct SNMP augmentation behavior

## Testing
- `pytest tests/test_topology_builder.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: nmap, httpx, requests, scapy, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68afe3671e9c8323b3bf099e6b0fe1d1