### PR TITLE
Add tests for static scan modules and Flutter button flow

### DIFF
--- a/nw_checker/test/static_scan_button_flow_test.dart
+++ b/nw_checker/test/static_scan_button_flow_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nw_checker/static_scan_tab.dart';
+
+void main() {
+  testWidgets('static scan button shows loading and results', (tester) async {
+    Future<Map<String, dynamic>> mockFetch() async {
+      await Future.delayed(const Duration(milliseconds: 10));
+      return {
+        'risk_score': 1,
+        'findings': [
+          {'category': 'demo', 'score': 1},
+        ],
+      };
+    }
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(body: StaticScanTab(fetcher: mockFetch)),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('staticButton')));
+    await tester.pump();
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('リスクスコア: 1'), findsOneWidget);
+    expect(find.text('demo'), findsOneWidget);
+  });
+
+  testWidgets('static scan button surfaces errors', (tester) async {
+    Future<Map<String, dynamic>> mockFetch() async {
+      throw Exception('fail');
+    }
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(body: StaticScanTab(fetcher: mockFetch)),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('staticButton')));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('fail'), findsOneWidget);
+    expect(find.text('再試行'), findsOneWidget);
+  });
+}

--- a/tests/integration/test_static_scan_run_all.py
+++ b/tests/integration/test_static_scan_run_all.py
@@ -1,0 +1,58 @@
+from src import static_scan
+from src.scans import (
+    ports,
+    os_banner,
+    smb_netbios,
+    upnp,
+    arp_spoof,
+    dhcp,
+    dns,
+    ssl_cert,
+)
+
+
+def _stub(module, score=1):
+    return lambda module=module: {
+        "category": module.__name__.split(".")[-1],
+        "score": score,
+        "details": {},
+    }
+
+
+def test_run_all_aggregates_scores(monkeypatch):
+    modules = [ports, os_banner, smb_netbios, upnp, arp_spoof, dhcp, dns, ssl_cert]
+    for mod in modules:
+        monkeypatch.setattr(mod, "scan", _stub(mod))
+
+    results = static_scan.run_all()
+    total = sum(item["score"] for item in results["findings"])
+    assert results["risk_score"] == total
+    categories = {f["category"] for f in results["findings"]}
+    assert categories == {
+        "ports",
+        "os_banner",
+        "smb_netbios",
+        "upnp",
+        "arp_spoof",
+        "dhcp",
+        "dns",
+        "ssl_cert",
+    }
+    assert [f["category"] for f in results["findings"]][:2] == ["ports", "os_banner"]
+
+
+def test_run_all_handles_module_errors(monkeypatch):
+    modules = [ports, os_banner, smb_netbios, upnp, arp_spoof, dhcp, dns, ssl_cert]
+    for mod in modules:
+        monkeypatch.setattr(mod, "scan", _stub(mod))
+
+    def boom():
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(dns, "scan", boom)
+
+    results = static_scan.run_all()
+    by_cat = {r["category"]: r for r in results["findings"]}
+    assert by_cat["dns"]["score"] == 0
+    assert by_cat["dns"]["details"]["error"] == "boom"
+    assert results["risk_score"] == len(modules) - 1

--- a/tests/test_new_scan_modules.py
+++ b/tests/test_new_scan_modules.py
@@ -1,0 +1,155 @@
+import types
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from src.scans import dns, dhcp, ssl_cert, arp_spoof
+
+
+def test_dns_scan_success(monkeypatch):
+    class FakeResp:
+        ancount = 1
+        arcount = 0
+        ad = 1
+
+        def __getitem__(self, item):
+            return self
+
+        def haslayer(self, layer):  # noqa: D401
+            return True
+
+    monkeypatch.setattr(dns, "_get_nameservers", lambda path="/etc/resolv.conf": ["8.8.8.8"])
+    monkeypatch.setattr(dns, "sr1", lambda *_, **__: FakeResp())
+    result = dns.scan()
+    assert result["score"] == 1
+    assert result["details"]["servers"] == ["8.8.8.8"]
+    assert any("External DNS" in w for w in result["details"]["warnings"])
+
+
+def test_dns_scan_error(monkeypatch):
+    monkeypatch.setattr(dns, "sr1", lambda *_, **__: (_ for _ in ()).throw(RuntimeError("boom")))
+    result = dns.scan()
+    assert result["score"] == 0
+    assert "boom" in result["details"]["error"]
+
+
+def test_dns_scan_dnssec_disabled(monkeypatch):
+    class FakeResp:
+        ancount = 1
+        arcount = 0
+        ad = 0
+
+        def __getitem__(self, item):
+            return self
+
+        def haslayer(self, layer):  # noqa: D401
+            return True
+
+    monkeypatch.setattr(dns, "_get_nameservers", lambda path="/etc/resolv.conf": ["192.168.1.1"])
+    monkeypatch.setattr(dns, "sr1", lambda *_, **__: FakeResp())
+    result = dns.scan()
+    assert result["score"] == 1
+    assert result["details"]["dnssec_enabled"] is False
+    assert any("DNSSEC is disabled" in w for w in result["details"]["warnings"])
+
+
+def test_dhcp_scan_success(monkeypatch):
+    class FakePkt:
+        def __contains__(self, layer):  # noqa: D401
+            return True
+
+        def __getitem__(self, layer):  # noqa: D401
+            return types.SimpleNamespace(src="1.2.3.4")
+
+    monkeypatch.setattr(dhcp, "srp", lambda *_, **__: ([(None, FakePkt())], None))
+    result = dhcp.scan()
+    assert result["score"] == 1
+    assert result["details"]["servers"] == ["1.2.3.4"]
+
+
+def test_dhcp_scan_error(monkeypatch):
+    monkeypatch.setattr(dhcp, "srp", lambda *_, **__: (_ for _ in ()).throw(RuntimeError("dhcp fail")))
+    result = dhcp.scan()
+    assert result["score"] == 0
+    assert "dhcp fail" in result["details"]["error"]
+
+
+def test_dhcp_scan_no_servers(monkeypatch):
+    monkeypatch.setattr(dhcp, "srp", lambda *_, **__: ([], None))
+    result = dhcp.scan()
+    assert result["score"] == 0
+    assert result["details"]["servers"] == []
+
+
+class DummySock:
+    def __init__(self, cert=None):
+        self.cert = cert or {}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):  # noqa: D401, ARG002
+        return False
+
+    def getpeercert(self):
+        return self.cert
+
+
+@pytest.fixture
+def _ssl_context(monkeypatch):
+    future = datetime.now(timezone.utc) + timedelta(days=60)
+    not_after = future.strftime("%b %d %H:%M:%S %Y GMT")
+
+    class DummyContext:
+        def wrap_socket(self, sock, server_hostname=None):
+            return DummySock({
+                "notAfter": not_after,
+                "issuer": ((("commonName", "Let's Encrypt"),),),
+            })
+
+    monkeypatch.setattr(ssl_cert.ssl, "create_default_context", lambda: DummyContext())
+    monkeypatch.setattr(ssl_cert.socket, "create_connection", lambda *_, **__: DummySock())
+
+
+def test_ssl_cert_scan_success(_ssl_context):
+    result = ssl_cert.scan("example.com")
+    assert result["score"] == 0
+    assert result["details"]["issuer"] == "Let's Encrypt"
+
+
+def test_ssl_cert_scan_error(monkeypatch):
+    def boom(*args, **kwargs):  # noqa: D401, ARG001, ARG002
+        raise OSError("connect fail")
+
+    monkeypatch.setattr(ssl_cert.socket, "create_connection", boom)
+    result = ssl_cert.scan("example.com")
+    assert result["score"] == 0
+    assert "connect fail" in result["details"]["error"]
+
+
+def test_arp_spoof_scan_success(monkeypatch):
+    tables = [{}, {arp_spoof.FAKE_IP: arp_spoof.FAKE_MAC}]
+    monkeypatch.setattr(arp_spoof, "_get_arp_table", lambda: tables.pop(0))
+    monkeypatch.setattr(arp_spoof, "send", lambda *_, **__: None)
+    monkeypatch.setattr(arp_spoof.time, "sleep", lambda _: None)
+    result = arp_spoof.scan(wait=0)
+    assert result["score"] == 5
+    assert result["details"]["vulnerable"] is True
+
+
+def test_arp_spoof_scan_error(monkeypatch):
+    monkeypatch.setattr(arp_spoof, "_get_arp_table", lambda: (_ for _ in ()).throw(RuntimeError("table fail")))
+    result = arp_spoof.scan(wait=0)
+    assert result["score"] == 0
+    assert "table fail" in result["details"]["error"]
+
+
+def test_arp_spoof_scan_not_vulnerable(monkeypatch):
+    tables = [{}, {}]
+    monkeypatch.setattr(arp_spoof, "_get_arp_table", lambda: tables.pop(0))
+    monkeypatch.setattr(arp_spoof, "send", lambda *_, **__: None)
+    monkeypatch.setattr(arp_spoof.time, "sleep", lambda _: None)
+    result = arp_spoof.scan(wait=0)
+    assert result["score"] == 0
+    assert result["details"]["vulnerable"] is False
+    assert "No ARP poisoning" in result["details"]["explanation"]


### PR DESCRIPTION
## Summary
- extend DNS, DHCP, and ARP spoof unit tests with DNSSEC-disabled, no-server, and non-vulnerable cases
- verify `static_scan.run_all` aggregates all modules and maintains risk score when a scan fails
- check Flutter static scan button flow for loading, results, and surfaced errors

## Testing
- `pytest`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_68b0125a116c83238fe93da9e1b3efa4