### PR TITLE
Flag dangerous network protocols and highlight in scan results

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -98,19 +98,21 @@ def _aggregate_results(records: list[dict]) -> dict:
     """
 
     dangerous_list = [
-        r.get("protocol", "").lower()
+        (r.get("protocol") or "unknown").lower()
         for r in records
-        if r.get("protocol", "").lower() in analyze.DANGEROUS_PROTOCOLS
+        if r.get("dangerous_protocol")
     ]
     score = len(dangerous_list)
-    dangerous = set(dangerous_list)
+    dangerous = sorted(set(dangerous_list))
     categories: list[dict] = []
     if dangerous:
-        categories.append({
-            "name": "protocols",
-            "severity": "high",
-            "issues": sorted(dangerous),
-        })
+        categories.append(
+            {
+                "name": "protocols",
+                "severity": "high",
+                "issues": dangerous,
+            }
+        )
     return {"risk_score": score, "categories": categories}
 
 

--- a/src/dynamic_scan/protocol_detector.py
+++ b/src/dynamic_scan/protocol_detector.py
@@ -5,7 +5,15 @@
 from typing import Optional
 
 # 危険とされるポート番号集合
-DANGEROUS_PORTS: set[int] = {21, 23, 3389, 445}
+# FTP(21), Telnet(23), RDP(3389), SMB(445) などの典型的な脆弱サービス
+# VNC やその他の管理用プロトコルも一緒に監視する
+DANGEROUS_PORTS: set[int] = {
+    21,  # FTP
+    23,  # Telnet
+    3389,  # RDP
+    445,  # SMB
+    5900,  # VNC
+}
 
 
 def is_dangerous_protocol(src_port: Optional[int], dst_port: Optional[int]) -> bool:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -36,7 +36,7 @@ def test_dynamic_scan_start_stop(monkeypatch, tmp_path):
 
     asyncio.run(
         api.scan_scheduler.storage.save_result(
-            {"protocol": "ftp", "src_ip": "1.1.1.1"}
+            {"protocol": "ftp", "src_ip": "1.1.1.1", "dangerous_protocol": True}
         )
     )
     resp3 = client.get("/scan/dynamic/results")

--- a/tests/test_api_dynamic_scan_alias.py
+++ b/tests/test_api_dynamic_scan_alias.py
@@ -56,7 +56,7 @@ def test_dynamic_scan_results_alias(monkeypatch, tmp_path):
     api.scan_scheduler = scheduler.DynamicScanScheduler()
     monkeypatch.setattr(storage, "Storage", lambda *args, **kwargs: store)
 
-    asyncio.run(api.scan_scheduler.storage.save_result({"protocol": "ftp"}))
+    asyncio.run(api.scan_scheduler.storage.save_result({"protocol": "ftp", "dangerous_protocol": True}))
 
     resp_old = client.get("/scan/dynamic/results")
     resp_new = client.get("/dynamic-scan/results")

--- a/tests/test_api_dynamic_scan_underscore_alias.py
+++ b/tests/test_api_dynamic_scan_underscore_alias.py
@@ -55,7 +55,7 @@ def test_dynamic_scan_results_underscore_alias(monkeypatch, tmp_path):
     api.scan_scheduler = scheduler.DynamicScanScheduler()
     monkeypatch.setattr(storage, "Storage", lambda *args, **kwargs: store)
 
-    asyncio.run(api.scan_scheduler.storage.save_result({"protocol": "ftp"}))
+    asyncio.run(api.scan_scheduler.storage.save_result({"protocol": "ftp", "dangerous_protocol": True}))
 
     resp_hyphen = client.get("/dynamic-scan/results")
     resp_underscore = client.get("/dynamic_scan/results")

--- a/tests/test_dynamic_scan.py
+++ b/tests/test_dynamic_scan.py
@@ -41,6 +41,7 @@ def test_reverse_dns_lookup(monkeypatch):
 
 def test_is_dangerous_protocol():
     assert protocol_detector.is_dangerous_protocol(23, 1000)
+    assert protocol_detector.is_dangerous_protocol(5900, None)
     assert not protocol_detector.is_dangerous_protocol(80, 8080)
     assert not protocol_detector.is_dangerous_protocol(None, None)
 


### PR DESCRIPTION
## Summary
- Expand dangerous port list and helper logic for protocol detection
- Aggregate scan results based on flagged dangerous protocols
- Test coverage for new ports and result aggregation

## Testing
- `pytest` *(fails: 18 errors during collection)*
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_68b018328e9c8323b62bedaf4580a0da