### PR TITLE
Implement traffic spike detection

### DIFF
--- a/src/dynamic_scan/traffic_anomaly.py
+++ b/src/dynamic_scan/traffic_anomaly.py
@@ -23,25 +23,15 @@ def update_traffic_stats(mac: str, bytes: int) -> None:
     """
     now = time.time()
     entry = _stats.get(mac)
-    if entry is None:
+    if entry is None or now - entry["last_seen"] > CONTINUOUS_GAP:
+        # 新規デバイスまたは通信が途切れていた場合は統計をリセット
         entry = {
             "history": deque(maxlen=MAX_SAMPLES),
-            "total": 0,
-            "count": 0,
             "start_time": now,
             "last_seen": now,
         }
         _stats[mac] = entry
-    else:
-        # 一定時間通信がなければ統計をリセット
-        if now - entry["last_seen"] > CONTINUOUS_GAP:
-            entry["history"].clear()
-            entry["total"] = 0
-            entry["count"] = 0
-            entry["start_time"] = now
     entry["history"].append(bytes)
-    entry["total"] += bytes
-    entry["count"] += 1
     entry["last_seen"] = now
 
 def detect_spike(mac: str) -> bool:
@@ -56,8 +46,11 @@ def detect_spike(mac: str) -> bool:
     # 常時通信の検出
     if now - entry["start_time"] > CONTINUOUS_DURATION:
         return True
-    latest = entry["history"][-1]
-    if entry["count"] == 1:
+    history = entry["history"]
+    if not history:
+        return False
+    latest = history[-1]
+    if len(history) == 1:
         return latest > SPIKE_THRESHOLD
-    avg = (entry["total"] - latest) / (entry["count"] - 1)
+    avg = (sum(history) - latest) / (len(history) - 1)
     return latest > avg + SPIKE_THRESHOLD


### PR DESCRIPTION
## Summary
- track per-device traffic stats and detect spikes or continuous traffic
- reset stats after communication gaps
- add regression tests for traffic anomaly handling

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'nmap')*
- `pytest tests/test_traffic_anomaly.py`

------
https://chatgpt.com/codex/tasks/task_e_68b0482ba95c8323b5883c887e0343da