### PR TITLE
feat: highlight dangerous protocols

### DIFF
--- a/nw_checker/lib/widgets/danger_badge.dart
+++ b/nw_checker/lib/widgets/danger_badge.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+/// 危険を示す赤色バッジ
+class DangerBadge extends StatelessWidget {
+  final EdgeInsetsGeometry padding;
+  const DangerBadge({super.key, this.padding = const EdgeInsets.symmetric(horizontal: 8, vertical: 4)});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: padding,
+      decoration: BoxDecoration(
+        color: Colors.red,
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: const Text(
+        'DANGER',
+        style: TextStyle(color: Colors.white),
+      ),
+    );
+  }
+}

--- a/nw_checker/lib/widgets/dynamic_scan_results.dart
+++ b/nw_checker/lib/widgets/dynamic_scan_results.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../models/scan_category.dart';
 import '../scan_result_detail_page.dart';
+import 'danger_badge.dart';
 import 'severity_badge.dart';
 
 /// 動的スキャン結果一覧ウィジェット。
@@ -23,7 +24,10 @@ class DynamicScanResults extends StatelessWidget {
                 (e) => ListTile(
                   title: Row(
                     children: [
-                      SeverityBadge(severity: cat.severity.name),
+                      if (cat.name == 'protocols')
+                        const DangerBadge()
+                      else
+                        SeverityBadge(severity: cat.severity.name),
                       const SizedBox(width: 8),
                       // 長いメッセージでも折り返せるようにする
                       Expanded(child: Text(e)),

--- a/nw_checker/lib/widgets/widgets.dart
+++ b/nw_checker/lib/widgets/widgets.dart
@@ -5,3 +5,4 @@ export 'alert_component.dart';
 export 'dynamic_scan_results.dart';
 export 'metric_card.dart';
 export 'severity_badge.dart';
+export 'danger_badge.dart';

--- a/nw_checker/test/dynamic_scan_results_test.dart
+++ b/nw_checker/test/dynamic_scan_results_test.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nw_checker/models/scan_category.dart';
 import 'package:nw_checker/widgets/dynamic_scan_results.dart';
-import 'package:nw_checker/widgets/severity_badge.dart';
+import 'package:nw_checker/widgets/danger_badge.dart';
 
 void main() {
   testWidgets('DynamicScanResults expands categories and shows issues', (
@@ -20,12 +20,10 @@ void main() {
     await tester.tap(find.text('protocols'));
     await tester.pumpAndSettle();
     expect(find.text('ftp'), findsOneWidget);
-    expect(find.byType(SeverityBadge), findsOneWidget);
-    final badge = tester.widget<SeverityBadge>(find.byType(SeverityBadge));
-    expect(badge.severity.toLowerCase(), 'high');
+    expect(find.byType(DangerBadge), findsOneWidget);
   });
 
-  testWidgets('SeverityBadge is red for high severity', (tester) async {
+  testWidgets('DangerBadge is red', (tester) async {
     final categories = [
       ScanCategory(name: 'protocols', severity: Severity.high, issues: ['ftp']),
     ];
@@ -38,7 +36,7 @@ void main() {
     await tester.pumpAndSettle();
     final container = tester.widget<Container>(
       find.descendant(
-        of: find.byType(SeverityBadge),
+        of: find.byType(DangerBadge),
         matching: find.byType(Container),
       ),
     );

--- a/src/dynamic_scan/protocol_detector.py
+++ b/src/dynamic_scan/protocol_detector.py
@@ -6,13 +6,17 @@ from typing import Optional
 
 # 危険とされるポート番号集合
 # FTP(21), Telnet(23), RDP(3389), SMB(445) などの典型的な脆弱サービス
-# VNC やその他の管理用プロトコルも一緒に監視する
+# VNC や WinRM(5985/5986) などの管理用プロトコルも監視対象とする
 DANGEROUS_PORTS: set[int] = {
     21,  # FTP
     23,  # Telnet
     3389,  # RDP
     445,  # SMB
     5900,  # VNC
+    5901,  # VNC alt
+    5985,  # WinRM HTTP
+    5986,  # WinRM HTTPS
+    2323,  # Telnet alternate
 }
 
 
@@ -23,8 +27,8 @@ def is_dangerous_protocol(src_port: Optional[int], dst_port: Optional[int]) -> b
     )
 
 
-def analyze_packet(packet) -> bool:
+def analyze_packet(pkt) -> bool:
     """パケット内のポートを解析し危険プロトコルか判定する"""
-    src = getattr(packet, "src_port", getattr(packet, "sport", None))
-    dst = getattr(packet, "dst_port", getattr(packet, "dport", None))
-    return is_dangerous_protocol(src, dst)
+    src_port = getattr(pkt, "src_port", getattr(pkt, "sport", None))
+    dst_port = getattr(pkt, "dst_port", getattr(pkt, "dport", None))
+    return is_dangerous_protocol(src_port, dst_port)

--- a/tests/test_dynamic_scan.py
+++ b/tests/test_dynamic_scan.py
@@ -54,6 +54,10 @@ def test_is_dangerous_protocol():
     assert not protocol_detector.is_dangerous_protocol(None, None)
 
 
+def test_is_dangerous_protocol_winrm():
+    assert protocol_detector.is_dangerous_protocol(5985, 80)
+
+
 def test_detect_dangerous_protocols_safe_ports():
     pkt = SimpleNamespace(protocol="HTTP", src_port=80, dst_port=8080)
     res = analyze.detect_dangerous_protocols(pkt)
@@ -62,6 +66,12 @@ def test_detect_dangerous_protocols_safe_ports():
 
 def test_detect_dangerous_protocols_dst_port():
     pkt = SimpleNamespace(protocol="RDP", src_port=80, dst_port=3389)
+    res = analyze.detect_dangerous_protocols(pkt)
+    assert res.dangerous_protocol is True
+
+
+def test_detect_dangerous_protocols_src_port():
+    pkt = SimpleNamespace(protocol="SMB", src_port=445, dst_port=1234)
     res = analyze.detect_dangerous_protocols(pkt)
     assert res.dangerous_protocol is True
 


### PR DESCRIPTION
## Summary
- expand list of dangerous ports and expose analyzer helper
- show red danger badge for risky protocols in dynamic scan results
- cover dangerous port detection and UI badge with tests

## Testing
- `pytest` *(fails: No module named 'graphviz', 'reportlab')*
- `cd nw_checker && flutter test`

------
https://chatgpt.com/codex/tasks/task_e_68b04822e61c8323a7b652429ba39462