### PR TITLE
ci: soften gates (lint/type/coverage as non-blocking)

### DIFF
--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -40,10 +40,22 @@ jobs:
         working-directory: nw_checker
         run: flutter pub get
 
+      - name: Run flutter analyze
+        if: ${{ steps.check_fl.outputs.exists == 'true' }}
+        working-directory: nw_checker
+        run: flutter analyze
+        continue-on-error: true
+
       - name: Run flutter tests
         if: ${{ steps.check_fl.outputs.exists == 'true' }}
         working-directory: nw_checker
         run: flutter test -r expanded
+
+      - name: Coverage threshold check
+        if: ${{ steps.check_fl.outputs.exists == 'true' }}
+        working-directory: nw_checker
+        run: flutter test --coverage
+        continue-on-error: true
 
       - name: Note when skipped
         if: ${{ steps.check_fl.outputs.exists != 'true' }}

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -34,6 +34,20 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt -r requirements-dev.txt
+      - name: Run ruff
+        run: ruff src tests
+        continue-on-error: true
+      - name: Run black --check
+        run: black --check src tests
+        continue-on-error: true
+      - name: Run mypy
+        run: mypy src
+        continue-on-error: true
+      - name: Coverage threshold check
+        run: |
+          coverage run -m pytest
+          coverage report --fail-under=80
+        continue-on-error: true
       - name: Run tests
         shell: bash
         run: pytest -m "not fastapi" -vv


### PR DESCRIPTION
## Summary
- make linting and type/coverage checks non-blocking in Python CI
- allow flutter analyze and coverage steps to fail without failing job

## Testing
- `pytest -q` *(fails: No module named 'nmap')*
- `flutter test -r expanded`

------
https://chatgpt.com/codex/tasks/task_e_68b116b56a748323ae67167d68d654ca