### PR TITLE
ci: enable strict gates (lint/type/coverage blocking)

### DIFF
--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -44,7 +44,6 @@ jobs:
         if: ${{ steps.check_fl.outputs.exists == 'true' }}
         working-directory: nw_checker
         run: flutter analyze
-        continue-on-error: true
 
       - name: Run flutter tests
         if: ${{ steps.check_fl.outputs.exists == 'true' }}
@@ -55,7 +54,6 @@ jobs:
         if: ${{ steps.check_fl.outputs.exists == 'true' }}
         working-directory: nw_checker
         run: flutter test --coverage
-        continue-on-error: true
 
       - name: Note when skipped
         if: ${{ steps.check_fl.outputs.exists != 'true' }}

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -36,18 +36,14 @@ jobs:
           pip install -r requirements.txt -r requirements-dev.txt
       - name: Run ruff
         run: ruff src tests
-        continue-on-error: true
       - name: Run black --check
         run: black --check src tests
-        continue-on-error: true
       - name: Run mypy
         run: mypy src
-        continue-on-error: true
       - name: Coverage threshold check
         run: |
           coverage run -m pytest
           coverage report --fail-under=80
-        continue-on-error: true
       - name: Run tests
         shell: bash
         run: pytest -m "not fastapi" -vv


### PR DESCRIPTION
## Summary
- enforce lint, type-checking, and coverage gates by removing `continue-on-error`

## Testing
- `pytest` *(fails: 18 errors during collection)*
- `cd nw_checker && flutter test`


------
https://chatgpt.com/codex/tasks/task_e_68b158508f748323be053a7fd59cce61