### PR TITLE
chore: improve python CI workflow

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -36,21 +36,14 @@ jobs:
           pip install -r requirements.txt -r requirements-dev.txt
       - name: Run ruff
         run: ruff src tests
-        continue-on-error: true
       - name: Run black --check
         run: black --check src tests
-        continue-on-error: true
       - name: Run mypy
         run: mypy src
-        continue-on-error: true
-      - name: Coverage threshold check
-        run: |
-          coverage run -m pytest
-          coverage report --fail-under=80
-        continue-on-error: true
-      - name: Run tests
+      - name: Run unit tests with coverage (gate)
         shell: bash
-        run: pytest -m "not fastapi" -vv
+        run: |
+          pytest -m "not fastapi and not slow" --cov=src --cov-report=term --cov-fail-under=80 -vv
 
   python-fastapi-tests:
     runs-on: ubuntu-latest

--- a/tests/test_python_ci_workflow.py
+++ b/tests/test_python_ci_workflow.py
@@ -5,6 +5,6 @@ def test_python_ci_has_fastapi_job():
     """python-ci workflow should include FastAPI test job"""
     workflow = Path(".github/workflows/python-ci.yml").read_text(encoding="utf-8")
     assert "python-tests:" in workflow
-    assert 'pytest -m "not fastapi" -vv' in workflow
+    assert 'pytest -m "not fastapi and not slow"' in workflow
     assert "python-fastapi-tests:" in workflow
     assert "pytest -m fastapi -vv" in workflow


### PR DESCRIPTION
## Summary
- remove leftover merge conflict markers and `continue-on-error` flags
- run coverage via pytest-cov with `not fastapi and not slow` marker filter
- adjust tests to reflect new workflow command

## Testing
- `ruff check src tests`
- `black --check src tests`
- `mypy src` *(fails: Incompatible types in assignment)*
- `pytest -m "not fastapi and not slow" --cov=src --cov-report=term --cov-fail-under=80 -vv`


------
https://chatgpt.com/codex/tasks/task_e_68b15b84fea0832384b3d6774924e0d4