### PR TITLE
feat: monitor more dangerous ports

### DIFF
--- a/src/dynamic_scan/protocol_detector.py
+++ b/src/dynamic_scan/protocol_detector.py
@@ -7,7 +7,8 @@ from typing import Optional
 
 # 危険とされるポート番号集合
 # FTP(21), Telnet(23), RDP(3389), SMB(445) などの典型的な脆弱サービス
-# VNC や WinRM(5985/5986) などの管理用プロトコルも監視対象とする
+# VNC や WinRM(5985/5986) などの管理用プロトコル、
+# データベース系サービスのポートも監視対象とする
 DANGEROUS_PORTS: set[int] = {
     21,  # FTP
     23,  # Telnet
@@ -18,6 +19,10 @@ DANGEROUS_PORTS: set[int] = {
     5985,  # WinRM HTTP
     5986,  # WinRM HTTPS
     2323,  # Telnet alternate
+    1433,  # Microsoft SQL Server
+    1521,  # Oracle DB
+    3306,  # MySQL
+    5432,  # PostgreSQL
 }
 
 

--- a/tests/test_dynamic_scan.py
+++ b/tests/test_dynamic_scan.py
@@ -49,6 +49,8 @@ def test_reverse_dns_lookup(monkeypatch):
 def test_is_dangerous_protocol():
     assert protocol_detector.is_dangerous_protocol(23, 1000)
     assert protocol_detector.is_dangerous_protocol(5900, None)
+    assert protocol_detector.is_dangerous_protocol(3389, None)
+    assert protocol_detector.is_dangerous_protocol(3306, None)
     assert not protocol_detector.is_dangerous_protocol(80, 8080)
     assert not protocol_detector.is_dangerous_protocol(None, None)
 


### PR DESCRIPTION
## Summary
- expand dangerous port list to include common database ports
- test detection for RDP and MySQL ports

## Testing
- `FORCE_RUN_PYTEST=1 bash codex_run_tests.sh` *(fails: name 'closing' is not defined; missing CI workflow files)*

------
https://chatgpt.com/codex/tasks/task_e_68b2b8cae9b08323b0bb18d5c0eeb0b0