### PR TITLE
feat(scan): expand dangerous ports and tests

### DIFF
--- a/src/dynamic_scan/device_tracker.py
+++ b/src/dynamic_scan/device_tracker.py
@@ -2,7 +2,6 @@ from contextlib import closing
 import asyncio
 import json
 import sqlite3
-from contextlib import closing
 from datetime import datetime
 from pathlib import Path
 from typing import List, Set

--- a/src/dynamic_scan/protocol_detector.py
+++ b/src/dynamic_scan/protocol_detector.py
@@ -18,6 +18,10 @@ DANGEROUS_PORTS: set[int] = {
     5985,  # WinRM HTTP
     5986,  # WinRM HTTPS
     2323,  # Telnet alternate
+    1433,  # Microsoft SQL Server
+    1521,  # Oracle DB
+    3306,  # MySQL
+    5432,  # PostgreSQL
 }
 
 

--- a/tests/test_dynamic_scan.py
+++ b/tests/test_dynamic_scan.py
@@ -57,6 +57,11 @@ def test_is_dangerous_protocol_winrm():
     assert protocol_detector.is_dangerous_protocol(5985, 80)
 
 
+def test_is_dangerous_protocol_db_ports():
+    assert protocol_detector.is_dangerous_protocol(1433, 80)
+    assert protocol_detector.is_dangerous_protocol(None, 3306)
+
+
 def test_detect_dangerous_protocols_safe_ports():
     pkt = SimpleNamespace(protocol="HTTP", src_port=80, dst_port=8080)
     res = analyze.detect_dangerous_protocols(pkt)


### PR DESCRIPTION
## Summary
- monitor additional database ports for dangerous protocol detection
- cover new ports with unit tests and fix duplicate import

## Testing
- `FORCE_RUN_PYTEST=1 bash codex_run_tests.sh` *(fails: 18 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b3b88539a883238a31ca8834e82365