### PR TITLE
feat: flag VNC HTTP port as dangerous

### DIFF
--- a/src/dynamic_scan/protocol_detector.py
+++ b/src/dynamic_scan/protocol_detector.py
@@ -13,6 +13,7 @@ DANGEROUS_PORTS: set[int] = {
     23,  # Telnet
     3389,  # RDP
     445,  # SMB
+    5800,  # VNC over HTTP
     5900,  # VNC
     5901,  # VNC alt
     5985,  # WinRM HTTP

--- a/tests/test_dynamic_scan.py
+++ b/tests/test_dynamic_scan.py
@@ -49,6 +49,7 @@ def test_reverse_dns_lookup(monkeypatch):
 def test_is_dangerous_protocol():
     assert protocol_detector.is_dangerous_protocol(23, 1000)
     assert protocol_detector.is_dangerous_protocol(5900, None)
+    assert protocol_detector.is_dangerous_protocol(5800, 80)
     assert not protocol_detector.is_dangerous_protocol(80, 8080)
     assert not protocol_detector.is_dangerous_protocol(None, None)
 


### PR DESCRIPTION
## Summary
- treat VNC HTTP (port 5800) as a dangerous management protocol
- test dangerous protocol detection for VNC HTTP traffic

## Testing
- `bash codex_run_tests.sh` *(fails: 20 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b3c88bbbc483239188bac376454beb